### PR TITLE
fix: virtual price rounding error

### DIFF
--- a/contracts/main/Twocrypto.vy
+++ b/contracts/main/Twocrypto.vy
@@ -902,14 +902,18 @@ def tweak_price(
     virtual_price: uint256 = 10**18
 
     if old_virtual_price > 0:
-
         xcp: uint256 = isqrt(xp[0] * xp[1])
+
+        # We increase the virtual price by 1 to avoid off by one rounding
+        # errors. While this can lead to a small profit overestimation,
+        # given virtual_price has 18 decimals, this is negligible.
         virtual_price = 10**18 * xcp // total_supply + 1
 
+        # Safe to do unsafe_div as old_virtual_price > 0.
         xcp_profit = unsafe_div(
             old_xcp_profit * virtual_price,
             old_virtual_price
-        )  # <---------------- Safu to do unsafe_div as old_virtual_price > 0.
+        )
 
         #       If A and gamma are not undergoing ramps (t < block.timestamp),
         #         ensure new virtual_price is not less than old virtual_price,

--- a/contracts/main/Twocrypto.vy
+++ b/contracts/main/Twocrypto.vy
@@ -904,7 +904,7 @@ def tweak_price(
     if old_virtual_price > 0:
 
         xcp: uint256 = isqrt(xp[0] * xp[1])
-        virtual_price = 10**18 * xcp // total_supply
+        virtual_price = 10**18 * xcp // total_supply + 1
 
         xcp_profit = unsafe_div(
             old_xcp_profit * virtual_price,
@@ -915,8 +915,7 @@ def tweak_price(
         #         ensure new virtual_price is not less than old virtual_price,
         #                                        else the pool suffers a loss.
         if self.future_A_gamma_time < block.timestamp:
-            # this usually reverts when withdrawing a very small amount of LP tokens
-            assert virtual_price > old_virtual_price # dev: virtual price decreased
+            assert virtual_price > old_virtual_price  # dev: virtual price decreased
 
     self.xcp_profit = xcp_profit
 

--- a/tests/stateful/test_stateful.py
+++ b/tests/stateful/test_stateful.py
@@ -230,10 +230,8 @@ class ImbalancedLiquidityStateful(OnlyBalancedLiquidityStateful):
         # TODO check these two conditions
         max_withdraw = 0.3 if depositor_ratio > 0.25 else 1
 
-        min_withdraw = 0.1 if depositor_balance >= 1e13 else 0.01
-
         # we draw a percentage of the depositor balance to withdraw
-        percentage = data.draw(floats(min_value=min_withdraw, max_value=max_withdraw))
+        percentage = data.draw(floats(min_value=0.01, max_value=max_withdraw))
 
         note(
             "removing {:.2e} lp tokens ".format(amount_withdrawn := percentage * depositor_balance)


### PR DESCRIPTION
In `tweak_price` the calculation of the virtual price can be off by 1 due to division rounding down.

In particular this line would revert:
https://github.com/curvefi/twocrypto-ng/blob/8621f90d39e8bd0762bbbd83dc32f3e6151318d3/contracts/main/Twocrypto.vy#L918

Because of this line lacking a `+ 1` previously:
https://github.com/curvefi/twocrypto-ng/blob/8621f90d39e8bd0762bbbd83dc32f3e6151318d3/contracts/main/Twocrypto.vy#L906-L907

While this issue doesn't seem to have cause issues onchain (probably it doesn't happen when pool is used as intended), this still create issues in testing and could potentially prevent people from withdrawing liquidity/exchanging. For this reason we increase the value of `virtual_price` by `1e-18` that can be considered a safe negligible amount that can hardly be misused given virtual price has 18 decimals of precision.

<!-- GitButler Footer Boundary Top -->
---
This is **part 2 of 3 in a stack** made with GitButler:
- <kbd>&nbsp;3&nbsp;</kbd> #20 
- <kbd>&nbsp;2&nbsp;</kbd> #19 👈 
- <kbd>&nbsp;1&nbsp;</kbd> #18 
<!-- GitButler Footer Boundary Bottom -->

