### PR TITLE
fix: onchain reverts

### DIFF
--- a/contracts/main/Twocrypto.vy
+++ b/contracts/main/Twocrypto.vy
@@ -232,11 +232,11 @@ def __init__(
     # --------------- Validate A and gamma parameters here and not in factory.
     gamma_A: uint256[2] = self._unpack_2(packed_gamma_A)  # gamma is at idx 0.
 
-    assert gamma_A[0] > MIN_GAMMA-1
-    assert gamma_A[0] < MAX_GAMMA+1
+    assert gamma_A[0] > MIN_GAMMA-1, "gamma<MIN"
+    assert gamma_A[0] < MAX_GAMMA+1, "gamma>MAX"
 
-    assert gamma_A[1] > MIN_A-1
-    assert gamma_A[1] < MAX_A+1
+    assert gamma_A[1] > MIN_A-1, "A<MIN"
+    assert gamma_A[1] < MAX_A+1, "A>MAX"
 
     self.initial_A_gamma = packed_gamma_A
     self.future_A_gamma = packed_gamma_A
@@ -310,7 +310,7 @@ def _transfer_in(
         # If we checked for received_amounts == dx, an extra transfer without a
         # call to exchange_received will break the method.
         dx: uint256 = coin_balance - self.balances[_coin_idx]
-        assert dx >= _dx  # dev: user didn't give us coins
+        assert dx >= _dx, "user didn't give us coins"
 
         # Adjust balances
         self.balances[_coin_idx] += dx
@@ -325,7 +325,7 @@ def _transfer_in(
         self,
         _dx,
         default_return_value=True
-    )
+    ), "transferFrom failed"
 
     dx: uint256 = staticcall IERC20(coins[_coin_idx]).balanceOf(self) - coin_balance
     self.balances[_coin_idx] += dx
@@ -351,7 +351,7 @@ def _transfer_out(_coin_idx: uint256, _amount: uint256, receiver: address):
         receiver,
         _amount,
         default_return_value=True
-    )
+    ), "transfer failed"
 
 
 # -------------------------- AMM Main Functions ------------------------------
@@ -472,7 +472,7 @@ def add_liquidity(
     d_token_fee: uint256 = 0
     old_D: uint256 = 0
 
-    assert amounts[0] + amounts[1] > 0  # dev: no coins to add
+    assert amounts[0] + amounts[1] > 0, "no coins to add"
 
     # --------------------- Get prices, balances -----------------------------
 
@@ -527,7 +527,7 @@ def add_liquidity(
     else:
         d_token = self.get_xcp(D, price_scale)  # <----- Making initial virtual price equal to 1.
 
-    assert d_token > 0  # dev: nothing minted
+    assert d_token > 0, "nothing minted"
 
     if old_D > 0:
 
@@ -553,7 +553,7 @@ def add_liquidity(
 
         self.mint(receiver, d_token)
 
-    assert d_token >= min_mint_amount, "Slippage"
+    assert d_token >= min_mint_amount, "slippage"
 
     # ---------------------------------------------- Log and claim admin fees.
 
@@ -614,7 +614,7 @@ def remove_liquidity(
         for i: uint256 in range(N_COINS):
 
             withdraw_amounts[i] = balances[i] * amount // total_supply
-            assert withdraw_amounts[i] >= min_amounts[i]
+            assert withdraw_amounts[i] >= min_amounts[i], "slippage"
 
     D: uint256 = self.D
     self.D = D - unsafe_div(D * amount, total_supply)  # <----------- Reduce D
@@ -672,7 +672,7 @@ def remove_liquidity_one_coin(
         (self.future_A_gamma_time > block.timestamp),  # <------- During ramps
     )  #                                                  we need to update D.
 
-    assert dy >= min_amount, "Slippage"
+    assert dy >= min_amount, "slippage"
 
     # ---------------------------- State Updates -----------------------------
 
@@ -747,8 +747,8 @@ def _exchange(
     min_dy: uint256,
 ) -> uint256[3]:
 
-    assert i != j  # dev: coin index out of range
-    assert dx_received > 0  # dev: do not exchange 0 coins
+    assert i != j, "same coin"
+    assert dx_received > 0, "zero dx"
 
     A_gamma: uint256[2] = self._A_gamma()
     xp: uint256[N_COINS] = self.balances
@@ -792,7 +792,7 @@ def _exchange(
 
     fee: uint256 = unsafe_div(self._fee(xp) * dy, 10**10)
     dy -= fee  # <--------------------- Subtract fee from the outgoing amount.
-    assert dy >= min_dy, "Slippage"
+    assert dy >= min_dy, "slippage"
     y -= dy
 
     y *= PRECISIONS[j]
@@ -915,7 +915,8 @@ def tweak_price(
         #         ensure new virtual_price is not less than old virtual_price,
         #                                        else the pool suffers a loss.
         if self.future_A_gamma_time < block.timestamp:
-            assert virtual_price > old_virtual_price  # dev: virtual price decreased
+            assert virtual_price > old_virtual_price, "virtual price decreased"
+
 
     self.xcp_profit = xcp_profit
 
@@ -1219,8 +1220,8 @@ def _calc_withdraw_one_coin(
 ) -> (uint256, uint256, uint256[N_COINS], uint256):
 
     token_supply: uint256 = self.totalSupply
-    assert token_amount <= token_supply  # dev: token amount more than supply
-    assert i < N_COINS  # dev: coin out of range
+    assert token_amount <= token_supply, "token amount more than supply"
+    assert i < N_COINS, "coin out of range"
 
     xx: uint256[N_COINS] = self.balances
     D0: uint256 = 0
@@ -1291,7 +1292,7 @@ def _approve(_owner: address, _spender: address, _value: uint256):
 
 @internal
 def _transfer(_from: address, _to: address, _value: uint256):
-    assert _to not in [self, empty(address)]
+    assert _to not in [self, empty(address)], "invalid receiver"
 
     self.balanceOf[_from] -= _value
     self.balanceOf[_to] += _value
@@ -1385,8 +1386,8 @@ def permit(
     @param _s The second 32 bytes of the ECDSA signature.
     @return bool Success.
     """
-    assert _owner != empty(address)  # dev: invalid owner
-    assert block.timestamp <= _deadline  # dev: permit expired
+    assert _owner != empty(address), "invalid owner"
+    assert block.timestamp <= _deadline, "permit expired"
 
     nonce: uint256 = self.nonces[_owner]
     digest: bytes32 = keccak256(
@@ -1400,7 +1401,7 @@ def permit(
             ),
         )
     )
-    assert ecrecover(digest, _v, _r, _s) == _owner  # dev: invalid signature
+    assert ecrecover(digest, _v, _r, _s) == _owner, "invalid signature"
 
     self.nonces[_owner] = unsafe_add(nonce, 1)  # <-- Unsafe add is safe here.
     self._approve(_owner, _spender, _value)
@@ -1773,26 +1774,26 @@ def ramp_A_gamma(
     @param future_gamma The future gamma value.
     @param future_time The timestamp at which the ramping will end.
     """
-    assert msg.sender == staticcall factory.admin()  # dev: only owner
-    assert block.timestamp > self.future_A_gamma_time # dev: ramp undergoing
-    assert future_time > block.timestamp + MIN_RAMP_TIME - 1  # dev: insufficient time
+    assert msg.sender == staticcall factory.admin(), "only owner"
+    assert block.timestamp > self.future_A_gamma_time, "ramp undergoing"
+    assert future_time > block.timestamp + MIN_RAMP_TIME - 1, "ramp time<min"
 
     A_gamma: uint256[2] = self._A_gamma()
     initial_A_gamma: uint256 = A_gamma[0] << 128
     initial_A_gamma = initial_A_gamma | A_gamma[1]
 
-    assert future_A > MIN_A - 1
-    assert future_A < MAX_A + 1
-    assert future_gamma > MIN_GAMMA - 1
-    assert future_gamma < MAX_GAMMA + 1
+    assert future_A > MIN_A - 1, "A<min"
+    assert future_A < MAX_A + 1, "A>max"
+    assert future_gamma > MIN_GAMMA - 1, "gamma<min"
+    assert future_gamma < MAX_GAMMA + 1, "gamme>max"
 
     ratio: uint256 = 10**18 * future_A // A_gamma[0]
-    assert ratio < 10**18 * MAX_A_CHANGE + 1 # dev: A change too high
-    assert ratio > 10**18 // MAX_A_CHANGE - 1 # dev: A change too low
+    assert ratio < 10**18 * MAX_A_CHANGE + 1, "A change too high"
+    assert ratio > 10**18 // MAX_A_CHANGE - 1, "A change too low"
 
     ratio = 10**18 * future_gamma // A_gamma[1]
-    assert ratio < 10**18 * MAX_A_CHANGE + 1 # dev: gamma change too high
-    assert ratio > 10**18 // MAX_A_CHANGE - 1 # dev: gamma change too low
+    assert ratio < 10**18 * MAX_A_CHANGE + 1, "gamma change too high"
+    assert ratio > 10**18 // MAX_A_CHANGE - 1, "gamma change too low"
 
     self.initial_A_gamma = initial_A_gamma
     self.initial_A_gamma_time = block.timestamp
@@ -1818,7 +1819,7 @@ def stop_ramp_A_gamma():
     @notice Stop Ramping A and gamma parameters immediately.
     @dev Only accessible by factory admin.
     """
-    assert msg.sender == staticcall factory.admin()  # dev: only owner
+    assert msg.sender == staticcall factory.admin(), "only owner"
 
     A_gamma: uint256[2] = self._A_gamma()
     current_A_gamma: uint256 = A_gamma[0] << 128
@@ -1853,7 +1854,7 @@ def apply_new_parameters(
     @param _new_adjustment_step The new adjustment step.
     @param _new_ma_time The new ma time. ma_time is time_in_seconds/ln(2).
     """
-    assert msg.sender == staticcall factory.admin()  # dev: only owner
+    assert msg.sender == staticcall factory.admin(), "only owner"
 
     # ----------------------------- Set fee params ---------------------------
 
@@ -1864,16 +1865,16 @@ def apply_new_parameters(
     current_fee_params: uint256[3] = self._unpack_3(self.packed_fee_params)
 
     if new_out_fee < MAX_FEE + 1:
-        assert new_out_fee > MIN_FEE - 1  # dev: fee is out of range
+        assert new_out_fee > MIN_FEE - 1, "fee is out of range"
     else:
         new_out_fee = current_fee_params[1]
 
     if new_mid_fee > MAX_FEE:
         new_mid_fee = current_fee_params[0]
-    assert new_mid_fee <= new_out_fee  # dev: mid-fee is too high
+    assert new_mid_fee <= new_out_fee, "mid-fee is too high"
 
     if new_fee_gamma < 10**18:
-        assert new_fee_gamma > 0  # dev: fee_gamma out of range [1 .. 10**18]
+        assert new_fee_gamma > 0, "fee_gamma out of range [1 .. 10**18]"
     else:
         new_fee_gamma = current_fee_params[2]
 
@@ -1894,7 +1895,7 @@ def apply_new_parameters(
         new_adjustment_step = current_rebalancing_params[1]
 
     if new_ma_time < 872542:  # <----- Calculated as: 7 * 24 * 60 * 60 / ln(2)
-        assert new_ma_time > 86  # dev: MA time should be longer than 60/ln(2)
+        assert new_ma_time > 86, "MA time should be longer than 60/ln(2)"
     else:
         new_ma_time = current_rebalancing_params[2]
 

--- a/contracts/main/Twocrypto.vy
+++ b/contracts/main/Twocrypto.vy
@@ -904,7 +904,7 @@ def tweak_price(
     if old_virtual_price > 0:
 
         xcp: uint256 = isqrt(xp[0] * xp[1])
-        virtual_price = 10**18 * xcp // total_supply
+        virtual_price = 10**18 * xcp // total_supply + 1
 
         xcp_profit = unsafe_div(
             old_xcp_profit * virtual_price,
@@ -915,8 +915,7 @@ def tweak_price(
         #         ensure new virtual_price is not less than old virtual_price,
         #                                        else the pool suffers a loss.
         if self.future_A_gamma_time < block.timestamp:
-            # this usually reverts when withdrawing a very small amount of LP tokens
-            assert virtual_price > old_virtual_price # dev: virtual price decreased
+            assert virtual_price > old_virtual_price  # dev: virtual price decreased
 
     self.xcp_profit = xcp_profit
 

--- a/contracts/main/TwocryptoFactory.vy
+++ b/contracts/main/TwocryptoFactory.vy
@@ -98,8 +98,8 @@ def __init__():
 @external
 def initialise_ownership(_fee_receiver: address, _admin: address):
 
-    assert msg.sender == self.deployer
-    assert self.admin == empty(address)
+    assert msg.sender == self.deployer, "deployer only"
+    assert self.admin == empty(address), "already initialised"
 
     self.fee_receiver = _fee_receiver
     self.admin = _admin
@@ -152,32 +152,32 @@ def deploy_pool(
     """
     pool_implementation: address = self.pool_implementations[implementation_id]
     _math_implementation: address = self.math_implementation
-    assert pool_implementation != empty(address), "Pool implementation not set"
-    assert _math_implementation != empty(address), "Math implementation not set"
+    assert pool_implementation != empty(address), "pool implementation not set"
+    assert _math_implementation != empty(address), "math implementation not set"
 
-    assert mid_fee < MAX_FEE-1  # mid_fee can be zero
-    assert out_fee >= mid_fee
-    assert out_fee < MAX_FEE-1
-    assert fee_gamma < 10**18+1
-    assert fee_gamma > 0
+    assert mid_fee < MAX_FEE-1, "fee mid>max"  # mid_fee can be zero
+    assert out_fee >= mid_fee, "fee out<mid"
+    assert out_fee < MAX_FEE-1, "fee out>max"
+    assert fee_gamma < 10**18+1, "fee_gamma>max"
+    assert fee_gamma > 0, "fee_gamma==0"
 
-    assert allowed_extra_profit < 10**18+1
+    assert allowed_extra_profit < 10**18+1, "allowed_extra_profit>max"
 
-    assert adjustment_step < 10**18+1
-    assert adjustment_step > 0
+    assert adjustment_step < 10**18+1, "adjustment_step>max"
+    assert adjustment_step > 0, "adjustment_step==0"
 
-    assert ma_exp_time < 872542  # 7 * 24 * 60 * 60 / ln(2)
-    assert ma_exp_time > 86  # 60 / ln(2)
+    assert ma_exp_time < 872542, "ma_exp_time>max"  # 7 * 24 * 60 * 60 / ln(2)
+    assert ma_exp_time > 86, "ma_exp_time<min" # 60 / ln(2)
 
-    assert initial_price > 10**6 and initial_price < 10**30  # dev: initial price out of bound
+    assert initial_price > 10**6 and initial_price < 10**30, "initial price out of bound"
 
-    assert _coins[0] != _coins[1], "Duplicate coins"
+    assert _coins[0] != _coins[1], "same coins"
 
     decimals: uint256[N_COINS] = empty(uint256[N_COINS])
     precisions: uint256[N_COINS] = empty(uint256[N_COINS])
     for i: uint256 in range(N_COINS):
         d: uint256 = convert(staticcall IERC20(_coins[i]).decimals(), uint256)
-        assert d < 19, "Max 18 decimals for coins"
+        assert d < 19, "max 18 decimals for coins"
         decimals[i] = d
         precisions[i] = 10 ** (18 - d)
 
@@ -258,9 +258,9 @@ def deploy_gauge(_pool: address) -> address:
     @param _pool Factory pool address to deploy a gauge for
     @return Address of the deployed gauge
     """
-    assert self.pool_data[_pool].coins[0] != empty(address), "Unknown pool"
-    assert self.pool_data[_pool].liquidity_gauge == empty(address), "Gauge already deployed"
-    assert self.gauge_implementation != empty(address), "Gauge implementation not set"
+    assert self.pool_data[_pool].coins[0] != empty(address), "unknown pool"
+    assert self.pool_data[_pool].liquidity_gauge == empty(address), "gauge already deployed"
+    assert self.gauge_implementation != empty(address), "gauge implementation not set"
 
     gauge: address = create_from_blueprint(self.gauge_implementation, _pool, code_offset=3)
     self.pool_data[_pool].liquidity_gauge = gauge
@@ -278,7 +278,7 @@ def set_fee_receiver(_fee_receiver: address):
     @notice Set fee receiver
     @param _fee_receiver Address that fees are sent to
     """
-    assert msg.sender == self.admin, "dev: admin only"
+    assert msg.sender == self.admin, "admin only"
 
     log UpdateFeeReceiver(self.fee_receiver, _fee_receiver)
     self.fee_receiver = _fee_receiver
@@ -294,7 +294,7 @@ def set_pool_implementation(
     @param _pool_implementation Address of the new pool implementation
     @param _implementation_index Index of the pool implementation
     """
-    assert msg.sender == self.admin, "dev: admin only"
+    assert msg.sender == self.admin, "admin only"
 
     log UpdatePoolImplementation(
         _implementation_index,
@@ -312,7 +312,7 @@ def set_gauge_implementation(_gauge_implementation: address):
     @dev Set to empty(address) to prevent deployment of new gauges
     @param _gauge_implementation Address of the new token implementation
     """
-    assert msg.sender == self.admin, "dev: admin only"
+    assert msg.sender == self.admin, "admin only"
 
     log UpdateGaugeImplementation(self.gauge_implementation, _gauge_implementation)
     self.gauge_implementation = _gauge_implementation
@@ -324,7 +324,7 @@ def set_views_implementation(_views_implementation: address):
     @notice Set views contract implementation
     @param _views_implementation Address of the new views contract
     """
-    assert msg.sender == self.admin,  "dev: admin only"
+    assert msg.sender == self.admin,  "admin only"
 
     log UpdateViewsImplementation(self.views_implementation, _views_implementation)
     self.views_implementation = _views_implementation
@@ -336,7 +336,7 @@ def set_math_implementation(_math_implementation: address):
     @notice Set math implementation
     @param _math_implementation Address of the new math contract
     """
-    assert msg.sender == self.admin, "dev: admin only"
+    assert msg.sender == self.admin, "admin only"
 
     log UpdateMathImplementation(self.math_implementation, _math_implementation)
     self.math_implementation = _math_implementation
@@ -348,7 +348,7 @@ def commit_transfer_ownership(_addr: address):
     @notice Transfer ownership of this contract to `addr`
     @param _addr Address of the new owner
     """
-    assert msg.sender == self.admin, "dev: admin only"
+    assert msg.sender == self.admin, "admin only"
 
     self.future_admin = _addr
 
@@ -359,7 +359,7 @@ def accept_transfer_ownership():
     @notice Accept a pending ownership transfer
     @dev Only callable by the new owner
     """
-    assert msg.sender == self.future_admin, "dev: future admin only"
+    assert msg.sender == self.future_admin, "future admin only"
 
     log TransferOwnership(self.admin, msg.sender)
     self.admin = msg.sender

--- a/contracts/main/TwocryptoMath.vy
+++ b/contracts/main/TwocryptoMath.vy
@@ -147,7 +147,7 @@ def _newton_y(ANN: uint256, gamma: uint256, x: uint256[N_COINS], D: uint256, i: 
     y: uint256 = D**2 // (x_j * N_COINS**2)
     K0_i: uint256 = (10**18 * N_COINS) * x_j // D
 
-    assert (K0_i >= unsafe_div(10**36, lim_mul)) and (K0_i <= lim_mul)  # dev: unsafe values x[i]
+    assert (K0_i >= unsafe_div(10**36, lim_mul)) and (K0_i <= lim_mul), "unsafe values x[i]"
 
     convergence_limit: uint256 = max(max(x_j // 10**14, D // 10**14), 100)
 
@@ -206,16 +206,16 @@ def _newton_y(ANN: uint256, gamma: uint256, x: uint256[N_COINS], D: uint256, i: 
 def newton_y(ANN: uint256, gamma: uint256, x: uint256[N_COINS], D: uint256, i: uint256) -> uint256:
 
     # Safety checks
-    assert ANN > MIN_A - 1 and ANN < MAX_A + 1  # dev: unsafe values A
-    assert gamma > MIN_GAMMA - 1 and gamma < MAX_GAMMA + 1  # dev: unsafe values gamma
-    assert D > 10**17 - 1 and D < 10**15 * 10**18 + 1 # dev: unsafe values D
+    assert ANN > MIN_A - 1 and ANN < MAX_A + 1, "unsafe values A"
+    assert gamma > MIN_GAMMA - 1 and gamma < MAX_GAMMA + 1, "unsafe values gamma"
+    assert D > 10**17 - 1 and D < 10**15 * 10**18 + 1, "unsafe values D"
     lim_mul: uint256 = 100 * 10**18  # 100.0
     if gamma > MAX_GAMMA_SMALL:
         lim_mul = unsafe_div(unsafe_mul(lim_mul, MAX_GAMMA_SMALL), gamma)  # smaller than 100.0
 
     y: uint256 = self._newton_y(ANN, gamma, x, D, i, lim_mul)
     frac: uint256 = y * 10**18 // D
-    assert (frac >= unsafe_div(10**36 // N_COINS, lim_mul)) and (frac <= unsafe_div(lim_mul, N_COINS))  # dev: unsafe value for y
+    assert (frac >= unsafe_div(10**36 // N_COINS, lim_mul)) and (frac <= unsafe_div(lim_mul, N_COINS)), "unsafe value for y"
 
     return y
 
@@ -231,9 +231,9 @@ def get_y(
 ) -> uint256[2]:
 
     # Safety checks
-    assert _ANN > MIN_A - 1 and _ANN < MAX_A + 1  # dev: unsafe values A
-    assert _gamma > MIN_GAMMA - 1 and _gamma < MAX_GAMMA + 1  # dev: unsafe values gamma
-    assert _D > 10**17 - 1 and _D < 10**15 * 10**18 + 1 # dev: unsafe values D
+    assert _ANN > MIN_A - 1 and _ANN < MAX_A + 1, "unsafe values A"
+    assert _gamma > MIN_GAMMA - 1 and _gamma < MAX_GAMMA + 1, "unsafe values gamma"
+    assert _D > 10**17 - 1 and _D < 10**15 * 10**18 + 1, "unsafe values D"
     lim_mul: uint256 = 100 * 10**18  # 100.0
     if _gamma > MAX_GAMMA_SMALL:
         lim_mul = unsafe_div(unsafe_mul(lim_mul, MAX_GAMMA_SMALL), _gamma)  # smaller than 100.0
@@ -250,7 +250,7 @@ def get_y(
 
     # K0_i: int256 = (10**18 * N_COINS) * x_j / D
     K0_i: int256 = unsafe_div(10**18 * convert(N_COINS, int256) * x_j, D)
-    assert (K0_i >= unsafe_div(10**36, lim_mul_signed)) and (K0_i <= lim_mul_signed)  # dev: unsafe values x[i]
+    assert (K0_i >= unsafe_div(10**36, lim_mul_signed)) and (K0_i <= lim_mul_signed), "unsafe values x[i]"
 
     ann_gamma2: int256 = ANN * gamma2
 
@@ -362,7 +362,7 @@ def get_y(
     y_out: uint256[2] = [convert(unsafe_div(unsafe_div(unsafe_mul(unsafe_div(D**2, x_j), root), 4), 10**18), uint256), convert(root, uint256)]
 
     frac: uint256 = unsafe_div(y_out[0] * 10**18, _D)
-    assert (frac >= unsafe_div(10**36 // N_COINS, lim_mul)) and (frac <= unsafe_div(lim_mul, N_COINS))  # dev: unsafe value for y
+    assert (frac >= unsafe_div(10**36 // N_COINS, lim_mul)) and (frac <= unsafe_div(lim_mul, N_COINS)), "unsafe value for y"
 
     return y_out
 
@@ -377,16 +377,16 @@ def newton_D(ANN: uint256, gamma: uint256, x_unsorted: uint256[N_COINS], K0_prev
     """
 
     # Safety checks
-    assert ANN > MIN_A - 1 and ANN < MAX_A + 1  # dev: unsafe values A
-    assert gamma > MIN_GAMMA - 1 and gamma < MAX_GAMMA + 1  # dev: unsafe values gamma
+    assert ANN > MIN_A - 1 and ANN < MAX_A + 1, "unsafe values A"
+    assert gamma > MIN_GAMMA - 1 and gamma < MAX_GAMMA + 1, "unsafe values gamma"
 
     # Initial value of invariant D is that for constant-product invariant
     x: uint256[N_COINS] = x_unsorted
     if x[0] < x[1]:
         x = [x_unsorted[1], x_unsorted[0]]
 
-    assert x[0] > 10**9 - 1 and x[0] < 10**15 * 10**18 + 1  # dev: unsafe values x[0]
-    assert unsafe_div(x[1] * 10**18, x[0]) > 10**14 - 1  # dev: unsafe values x[i] (input)
+    assert x[0] > 10**9 - 1 and x[0] < 10**15 * 10**18 + 1, "unsafe values x[0]"
+    assert unsafe_div(x[1] * 10**18, x[0]) > 10**14 - 1, "unsafe values x[i] (input)"
 
     S: uint256 = unsafe_add(x[0], x[1])  # can unsafe add here because we checked x[0] bounds
 
@@ -404,7 +404,7 @@ def newton_D(ANN: uint256, gamma: uint256, x_unsorted: uint256[N_COINS], K0_prev
 
     for i: uint256 in range(255):
         D_prev: uint256 = D
-        assert D > 0
+        assert D > 0, "D==0"
         # Unsafe division by D and D_prev is now safe
 
         # K0: uint256 = 10**18
@@ -450,7 +450,7 @@ def newton_D(ANN: uint256, gamma: uint256, x_unsorted: uint256[N_COINS], K0_prev
 
             for _x: uint256 in x:
                 frac: uint256 = _x * 10**18 // D
-                assert (frac > 10**16 // N_COINS - 1) and (frac < 10**20 // N_COINS + 1)  # dev: unsafe values x[i]
+                assert (frac > 10**16 // N_COINS - 1) and (frac < 10**20 // N_COINS + 1), "unsafe values x[i]"
             return D
 
     raise "Did not converge"
@@ -469,7 +469,7 @@ def get_p(
     @param _A_gamma Amplification coefficient and gamma.
     """
 
-    assert _D > 10**17 - 1 and _D < 10**15 * 10**18 + 1  # dev: unsafe D values
+    assert _D > 10**17 - 1 and _D < 10**15 * 10**18 + 1, "unsafe D values"
 
     # K0 = P * N**N / D**N.
     # K0 is dimensionless and has 10**36 precision:

--- a/contracts/main/TwocryptoView.vy
+++ b/contracts/main/TwocryptoView.vy
@@ -309,8 +309,8 @@ def _calc_withdraw_one_coin(
 ) -> (uint256, uint256):
 
     token_supply: uint256 = staticcall Curve(swap).totalSupply()
-    assert token_amount <= token_supply  # dev: token amount more than supply
-    assert i < N_COINS  # dev: coin out of range
+    assert token_amount <= token_supply, "token amount more than supply"
+    assert i < N_COINS, "coin out of range"
 
     math: Math = staticcall Curve(swap).MATH()
 

--- a/tests/fuzzing/test_get_y.py
+++ b/tests/fuzzing/test_get_y.py
@@ -42,10 +42,10 @@ def test_get_y_revert(math_contract):
     D = 224824250915890636214130540882688
     i = 0
 
-    with boa.reverts(dev="unsafe values A"):
+    with boa.reverts("unsafe values A"):
         math_contract.newton_y(a, gamma, x, D, i)
 
-    with boa.reverts(dev="unsafe values A"):
+    with boa.reverts("unsafe values A"):
         math_contract.get_y(a, gamma, x, D, i)
 
 

--- a/tests/stateful/stateful_base.py
+++ b/tests/stateful/stateful_base.py
@@ -253,11 +253,9 @@ class StatefulBase(RuleBasedStateMachine):
 
             # we make sure that the revert was caused by the pool
             # being too imbalanced
-            if e.stack_trace.last_frame.dev_reason.reason_str not in (
-                "unsafe value for y",
-                "unsafe values x[i]",
-            ):
-                raise ValueError(f"Reverted for the wrong reason: {e}")
+            error = str(e.stack_trace[0])
+            if not any(msg in error for msg in ("unsafe value for y", "unsafe values x[i]")):
+                raise ValueError(f"Reverted for the wrong reason: {error}")
 
             # we use the log10 of the equilibrium to obtain an easy interval
             # to work with. If the pool is balanced the equilibrium is 1 and

--- a/tests/stateful/test_stateful.py
+++ b/tests/stateful/test_stateful.py
@@ -230,10 +230,8 @@ class ImbalancedLiquidityStateful(OnlyBalancedLiquidityStateful):
         # TODO check these two conditions
         max_withdraw = 0.3 if depositor_ratio > 0.25 else 1
 
-        min_withdraw = 0.1 if depositor_balance >= 1e13 else 0.01
-
         # we draw a percentage of the depositor balance to withdraw
-        percentage = data.draw(floats(min_value=min_withdraw, max_value=max_withdraw))
+        percentage = data.draw(floats(min_value=0.01, max_value=max_withdraw))
 
         note(
             "removing {:.2e} lp tokens ".format(amount_withdrawn := percentage * depositor_balance)

--- a/tests/unitary/factory/test_admin_methods.py
+++ b/tests/unitary/factory/test_admin_methods.py
@@ -3,30 +3,30 @@ import boa
 
 def test_revert_unauthorised_access(user, factory):
     with boa.env.prank(user):
-        with boa.reverts("dev: admin only"):
+        with boa.reverts("admin only"):
             factory.set_pool_implementation(boa.env.generate_address(), 0)
 
-        with boa.reverts("dev: admin only"):
+        with boa.reverts("admin only"):
             factory.set_gauge_implementation(boa.env.generate_address())
 
-        with boa.reverts("dev: admin only"):
+        with boa.reverts("admin only"):
             factory.set_views_implementation(boa.env.generate_address())
 
 
 def test_revert_unauthorised_set_fee_receiver(user, factory, fee_receiver):
     with boa.env.prank(user):
-        with boa.reverts("dev: admin only"):
+        with boa.reverts("admin only"):
             factory.set_fee_receiver(user)
 
     assert factory.fee_receiver() == fee_receiver
 
 
 def test_revert_unauthorised_new_admin(user, factory, owner):
-    with boa.env.prank(user), boa.reverts("dev: admin only"):
+    with boa.env.prank(user), boa.reverts("admin only"):
         factory.commit_transfer_ownership(user)
 
     with boa.env.prank(owner):
         factory.commit_transfer_ownership(boa.env.generate_address())
 
-    with boa.env.prank(user), boa.reverts("dev: future admin only"):
+    with boa.env.prank(user), boa.reverts("future admin only"):
         factory.accept_transfer_ownership()

--- a/tests/unitary/factory/test_deploy_pool.py
+++ b/tests/unitary/factory/test_deploy_pool.py
@@ -98,7 +98,7 @@ def test_revert_deploy_without_implementations(
     deployer,
 ):
     with boa.env.prank(deployer):
-        with boa.reverts("Pool implementation not set"):
+        with boa.reverts("pool implementation not set"):
             empty_factory.deploy_pool(
                 "Test",  # _name: String[64]
                 "Test",  # _symbol: String[32]

--- a/tests/unitary/pool/admin/test_revert_commit_params.py
+++ b/tests/unitary/pool/admin/test_revert_commit_params.py
@@ -70,5 +70,5 @@ def test_commit_rebalancing_params(swap, factory_admin, params):
 
 
 def test_revert_unauthorised_commit(swap, user, params):
-    with boa.env.prank(user), boa.reverts(dev="only owner"):
+    with boa.env.prank(user), boa.reverts("only owner"):
         _apply_new_params(swap, params)

--- a/tests/unitary/pool/admin/test_revert_ramp.py
+++ b/tests/unitary/pool/admin/test_revert_ramp.py
@@ -4,7 +4,7 @@ from tests.utils.constants import UNIX_DAY
 
 
 def test_revert_unauthorised_ramp(swap, user):
-    with boa.env.prank(user), boa.reverts(dev="only owner"):
+    with boa.env.prank(user), boa.reverts("only owner"):
         swap.ramp_A_gamma(1, 1, 1)
 
 
@@ -17,14 +17,14 @@ def test_revert_ramp_while_ramping(swap, factory_admin):
     with boa.env.prank(factory_admin):
         swap.ramp_A_gamma(A_gamma[0] + 1, A_gamma[1] + 1, future_time)
 
-        with boa.reverts(dev="ramp undergoing"):
+        with boa.reverts("ramp undergoing"):
             swap.ramp_A_gamma(A_gamma[0], A_gamma[1], future_time)
 
 
 def test_revert_fast_ramps(swap, factory_admin):
     A_gamma = [swap.A(), swap.gamma()]
     future_time = boa.env.evm.patch.timestamp + 10
-    with boa.env.prank(factory_admin), boa.reverts(dev="insufficient time"):
+    with boa.env.prank(factory_admin), boa.reverts("ramp time<min"):
         swap.ramp_A_gamma(A_gamma[0] + 1, A_gamma[1] + 1, future_time)
 
 
@@ -37,7 +37,7 @@ def test_revert_unauthorised_stop_ramp(swap, factory_admin, user):
     with boa.env.prank(factory_admin):
         swap.ramp_A_gamma(A_gamma[0] + 1, A_gamma[1] + 1, future_time)
 
-    with boa.env.prank(user), boa.reverts(dev="only owner"):
+    with boa.env.prank(user), boa.reverts("only owner"):
         swap.stop_ramp_A_gamma()
 
 
@@ -49,16 +49,16 @@ def test_revert_ramp_too_far(swap, factory_admin):
     gamma = swap.gamma()
     future_time = boa.env.evm.patch.timestamp + UNIX_DAY + 1
 
-    with boa.env.prank(factory_admin), boa.reverts(dev="A change too high"):
+    with boa.env.prank(factory_admin), boa.reverts("A change too high"):
         future_A = A * 11  # can at most increase by 10x
         swap.ramp_A_gamma(future_A, gamma, future_time)
-    with boa.env.prank(factory_admin), boa.reverts(dev="A change too low"):
+    with boa.env.prank(factory_admin), boa.reverts("A change too low"):
         future_A = A // 11  # can at most decrease by 10x
         swap.ramp_A_gamma(future_A, gamma, future_time)
 
-    with boa.env.prank(factory_admin), boa.reverts(dev="gamma change too high"):
+    with boa.env.prank(factory_admin), boa.reverts("gamma change too high"):
         future_gamma = gamma * 11  # can at most increase by 10x
         swap.ramp_A_gamma(A, future_gamma, future_time)
-    with boa.env.prank(factory_admin), boa.reverts(dev="gamma change too low"):
+    with boa.env.prank(factory_admin), boa.reverts("gamma change too low"):
         future_gamma = gamma // 11  # can at most decrease by 10x
         swap.ramp_A_gamma(A, future_gamma, future_time)

--- a/tests/unitary/pool/test_exchange.py
+++ b/tests/unitary/pool/test_exchange.py
@@ -138,5 +138,5 @@ def test_exchange_received_revert_on_no_transfer(
 
     calculated = views_contract.get_dy(i, j, amount, swap_with_deposit)
 
-    with boa.env.prank(user), boa.reverts(dev="user didn't give us coins"):
+    with boa.env.prank(user), boa.reverts("user didn't give us coins"):
         swap_with_deposit.exchange_received(i, j, amount, int(0.999 * calculated), user)


### PR DESCRIPTION
Historically Curve pools have been using dev reasons for errors to reduce the impact on codesize due to [EIP-170](https://eips.ethereum.org/EIPS/eip-170) limitations. However given the increasing amount of integrators for the cryptoswap algo, dev reasons have proven to be very hard to use for debugging for devs that are not using titanoboa.

Given twocrypto-ng has enough room to add onchain errors, I replaced all dev reasons with more tooling friendly onchain reverts.

<!-- GitButler Footer Boundary Top -->
---
This is **part 3 of 3 in a stack** made with GitButler:
- <kbd>&nbsp;3&nbsp;</kbd> #20 👈 
- <kbd>&nbsp;2&nbsp;</kbd> #19 
- <kbd>&nbsp;1&nbsp;</kbd> #18 
<!-- GitButler Footer Boundary Bottom -->

