### PR TITLE
refactor: snekmate math

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,6 +9,7 @@ requires-python = "==3.12.6"
 dependencies = [
     "vyper==0.4.0",
     "titanoboa", # Keep this as a placeholder in the dependencies array
+    "snekmate==0.1.0",
 ]
 
 [tool.uv.sources]

--- a/tests/fuzzing/test_exp.py
+++ b/tests/fuzzing/test_exp.py
@@ -17,7 +17,7 @@ from vyper.utils import SizeLimits
 @settings(max_examples=10000, deadline=None)
 def test_exp(math_optimized, x):
     if x >= 135305999368893231589:
-        with boa.reverts("Math: wad_exp overflow"):
+        with boa.reverts("math: wad_exp overflow"):
             math_optimized.wad_exp(x)
 
     elif x <= -42139678854452767551:


### PR DESCRIPTION
This PR introduces [snekmate](https://github.com/pcaversaccio/snekmate) as dependency for twocrypto-ng.

This PR **does not** contain code changes as in some way snekmate has always been a dependency for this project, however before vyper 0.4 it wasn't possible to import modules, so code had to be copy pasted manually.

Relying on snekmate's version of this function is safe because:
1. the two functions do not contain any change so they compile to the same bytecode.
2. snekmate's version has been pinned in the `.toml` file, so it won't change unless the dependency is explicitly updated.
3. snekmate contains more tests on top of what we test in our codebase.

More refactoring to further rely on snekmate's modules is left for future work.