### PR TITLE
fix: better rebalancing conditions

### DIFF
--- a/contracts/main/Twocrypto.vy
+++ b/contracts/main/Twocrypto.vy
@@ -924,7 +924,7 @@ def tweak_price(
     self.xcp_profit = xcp_profit
 
     # ------------ Rebalance liquidity if there's enough profits to adjust it:
-    if virtual_price * 2 - 10**18 > xcp_profit + 2 * rebalancing_params[0]:
+    if virtual_price ** 2 > xcp_profit * (10**18 + 2 * rebalancing_params[0]):
         #                          allowed_extra_profit --------^
 
         # ------------------- Get adjustment step ----------------------------
@@ -981,7 +981,7 @@ def tweak_price(
             # ---------------------------- Proceed if we've got enough profit.
             if (
                 old_virtual_price > 10**18 and
-                2 * old_virtual_price - 10**18 > xcp_profit
+                old_virtual_price ** 2 > xcp_profit * 10**18
             ):
 
                 self.D = D


### PR DESCRIPTION
From c2a8f09

This PR refines the comparison between xcp_profit and virtual_price by using a quadratic expression instead of a linear one. The motivation comes from empirical observations in simulations, where using a linear approximation led to mismatches in results (e.g., comparing different time periods). The quadratic expression aligns better with the expected behavior. 