### PR TITLE
refactor: remove initial guess from tweak_price

### DIFF
--- a/contracts/main/Twocrypto.vy
+++ b/contracts/main/Twocrypto.vy
@@ -859,8 +859,8 @@ def tweak_price(
     # see the whitepaper for more details.
     xp: uint256[N_COINS] = [
         unsafe_div(D, N_COINS),
-        D * PRECISION // (N_COINS * price_scale) 
-    ] 
+        D * PRECISION // (N_COINS * price_scale)
+    ]
 
     xcp_profit: uint256 = 10**18
     virtual_price: uint256 = 10**18
@@ -910,11 +910,11 @@ def tweak_price(
             rebalancing_params[1], unsafe_div(norm, 5)
         )  #           ^------------------------------------- adjustment_step.
 
-        # We only adjust prices if the vector distance between price_oracle 
+        # We only adjust prices if the vector distance between price_oracle
         # and price_scale is large enough. This check ensures that no rebalancing
-        # occurs if the distance is low i.e. the pool prices are pegged to the 
+        # occurs if the distance is low i.e. the pool prices are pegged to the
         # oracle prices.
-        if norm > adjustment_step:  
+        if norm > adjustment_step:
             # Calculate new price scale.
             p_new: uint256 = unsafe_div(
                 price_scale * unsafe_sub(norm, adjustment_step) +
@@ -941,7 +941,7 @@ def tweak_price(
             # unsafe_div because we did safediv before (if vp>1e18)
             new_virtual_price: uint256 = unsafe_div(
                 10**18 * isqrt(xp[0] * xp[1]), total_supply
-            )  
+            )
 
             # If we've got enough profit we rebalance the liquidity in the
             # pool by moving the price_scale closer to the oracle price.

--- a/tests/stateful/stateful_base.py
+++ b/tests/stateful/stateful_base.py
@@ -369,7 +369,7 @@ class StatefulBase(RuleBasedStateMachine):
         # 2. the function reverted because the virtual price
         # decreased (try block + boa.reverts)
         try:
-            with boa.reverts(dev="virtual price decreased"):
+            with boa.reverts("virtual price decreased"):
                 self.pool.remove_liquidity_one_coin(
                     lp_tokens_to_withdraw,
                     coin_idx,


### PR DESCRIPTION
This PR simplifies the flow in `tweak_price`, here's a list of the changes:
- Remove the initial guess argument (`K0_prev`) by moving the computation of D directly in the `_exchange` function.
- Rename `new_D` arg to just `D`, this is to reduce confusion in the function since there's actually a `new_D` value after rebalancing (previously just called `D`)
- Improve readability by renaming `old_virtual_price` -> `new_virtual_price` when it actually contains the new virtual price.
- Improved comments to help understand what's going on.