### PR TITLE
chore: remove permit

### DIFF
--- a/contracts/main/Twocrypto.vy
+++ b/contracts/main/Twocrypto.vy
@@ -190,16 +190,6 @@ balanceOf: public(HashMap[address, uint256])
 allowance: public(HashMap[address, HashMap[address, uint256]])
 totalSupply: public(uint256)
 
-EIP712_TYPEHASH: constant(bytes32) = keccak256(
-    "EIP712Domain(string name,string version,uint256 chainId,address verifyingContract,bytes32 salt)"
-)
-VERSION_HASH: constant(bytes32) = keccak256(version)
-NAME_HASH: immutable(bytes32)
-CACHED_CHAIN_ID: immutable(uint256)
-salt: public(immutable(bytes32))
-CACHED_DOMAIN_SEPARATOR: immutable(bytes32)
-
-
 # ----------------------- Contract -------------------------------------------
 
 @deploy
@@ -250,24 +240,6 @@ def __init__(
     self.last_prices = initial_price
     self.last_timestamp = block.timestamp
     self.xcp_profit_a = 10**18
-
-    #         Cache DOMAIN_SEPARATOR. If chain.id is not CACHED_CHAIN_ID, then
-    #     DOMAIN_SEPARATOR will be re-calculated each time `permit` is called.
-    #                   Otherwise, it will always use CACHED_DOMAIN_SEPARATOR.
-    #                       see: `_domain_separator()` for its implementation.
-    NAME_HASH = keccak256(name)
-    salt = _salt
-    CACHED_CHAIN_ID = chain.id
-    CACHED_DOMAIN_SEPARATOR = keccak256(
-        abi_encode(
-            EIP712_TYPEHASH,
-            NAME_HASH,
-            VERSION_HASH,
-            chain.id,
-            self,
-            salt,
-        )
-    )
 
     log Transfer(empty(address), self, 0)  # <------- Fire empty transfer from
     #                                       0x0 to self for indexers to catch.
@@ -1299,23 +1271,6 @@ def _transfer(_from: address, _to: address, _value: uint256):
     log Transfer(_from, _to, _value)
 
 
-@view
-@internal
-def _domain_separator() -> bytes32:
-    if chain.id != CACHED_CHAIN_ID:
-        return keccak256(
-            abi_encode(
-                EIP712_TYPEHASH,
-                NAME_HASH,
-                VERSION_HASH,
-                chain.id,
-                self,
-                salt,
-            )
-        )
-    return CACHED_DOMAIN_SEPARATOR
-
-
 @external
 def transferFrom(_from: address, _to: address, _value: uint256) -> bool:
     """
@@ -1699,16 +1654,6 @@ def fee_calc(xp: uint256[N_COINS]) -> uint256:  # <----- For by view contract.
     @return uint256 Fee value.
     """
     return self._fee(xp)
-
-
-@view
-@external
-def DOMAIN_SEPARATOR() -> bytes32:
-    """
-    @notice EIP712 domain separator.
-    @return bytes32 Domain Separator set for the current chain.
-    """
-    return self._domain_separator()
 
 
 # ------------------------- AMM Admin Functions ------------------------------

--- a/contracts/main/Twocrypto.vy
+++ b/contracts/main/Twocrypto.vy
@@ -189,13 +189,9 @@ version: public(constant(String[8])) = "v2.1.0"
 balanceOf: public(HashMap[address, uint256])
 allowance: public(HashMap[address, HashMap[address, uint256]])
 totalSupply: public(uint256)
-nonces: public(HashMap[address, uint256])
 
 EIP712_TYPEHASH: constant(bytes32) = keccak256(
     "EIP712Domain(string name,string version,uint256 chainId,address verifyingContract,bytes32 salt)"
-)
-EIP2612_TYPEHASH: constant(bytes32) = keccak256(
-    "Permit(address owner,address spender,uint256 value,uint256 nonce,uint256 deadline)"
 )
 VERSION_HASH: constant(bytes32) = keccak256(version)
 NAME_HASH: immutable(bytes32)
@@ -1360,54 +1356,6 @@ def approve(_spender: address, _value: uint256) -> bool:
     @return bool Success
     """
     self._approve(msg.sender, _spender, _value)
-    return True
-
-
-@external
-def permit(
-    _owner: address,
-    _spender: address,
-    _value: uint256,
-    _deadline: uint256,
-    _v: uint8,
-    _r: bytes32,
-    _s: bytes32,
-) -> bool:
-    """
-    @notice Permit `_spender` to spend up to `_value` amount of `_owner`'s
-            tokens via a signature.
-    @dev In the event of a chain fork, replay attacks are prevented as
-         domain separator is recalculated. However, this is only if the
-         resulting chains update their chainId.
-    @param _owner The account which generated the signature and is granting an
-                  allowance.
-    @param _spender The account which will be granted an allowance.
-    @param _value The approval amount.
-    @param _deadline The deadline by which the signature must be submitted.
-    @param _v The last byte of the ECDSA signature.
-    @param _r The first 32 bytes of the ECDSA signature.
-    @param _s The second 32 bytes of the ECDSA signature.
-    @return bool Success.
-    """
-    assert _owner != empty(address), "invalid owner"
-    assert block.timestamp <= _deadline, "permit expired"
-
-    nonce: uint256 = self.nonces[_owner]
-    digest: bytes32 = keccak256(
-        concat(
-            b"\x19\x01",
-            self._domain_separator(),
-            keccak256(
-                abi_encode(
-                    EIP2612_TYPEHASH, _owner, _spender, _value, nonce, _deadline
-                )
-            ),
-        )
-    )
-    assert ecrecover(digest, _v, _r, _s) == _owner, "invalid signature"
-
-    self.nonces[_owner] = unsafe_add(nonce, 1)  # <-- Unsafe add is safe here.
-    self._approve(_owner, _spender, _value)
     return True
 
 


### PR DESCRIPTION
This functionality didn't get a lot of adoption, and there's no need to have this built-in in our contracts when we can eventually rely on permit2 or even just [forget about it soon](https://eips.ethereum.org/EIPS/eip-3074)