### PR TITLE
feat: donations

### DIFF
--- a/contracts/main/Twocrypto.vy
+++ b/contracts/main/Twocrypto.vy
@@ -423,6 +423,11 @@ def exchange_received(
 def donate(amounts: uint256[N_COINS]):
     assert amounts[0] + amounts[1] > 0, "no coins to donate"
 
+    # We forbid donating when the pool is empty as we consider this
+    # undefined behavior.
+    balances: uint256[N_COINS] = self.balances
+    assert balances[0] + balances[1] > 0, "no coins in the pool"
+
     donation_balances: uint256[N_COINS] = self.donation_balances
 
     # Update the donation clock if there are no donations to be absorbed.

--- a/contracts/main/Twocrypto.vy
+++ b/contracts/main/Twocrypto.vy
@@ -1288,12 +1288,15 @@ def _calc_token_fee(amounts: uint256[N_COINS], xp: uint256[N_COINS]) -> uint256:
 @view
 def _calc_withdraw_one_coin(
     A_gamma: uint256[2],
-    token_amount: uint256,
+    amount: uint256,
     i: uint256,
 ) -> (uint256, uint256, uint256[N_COINS], uint256):
 
-    token_supply: uint256 = self.totalSupply
-    assert token_amount <= token_supply, "token amount more than supply"
+    # TODO do packing for these two
+    total_supply: uint256 = self.totalSupply
+    dead_supply: uint256 = self.dead_supply
+    adjusted_supply: uint256 = total_supply + dead_supply
+    assert amount <= total_supply, "token amount more than supply"
     assert i < N_COINS, "coin out of range"
 
 
@@ -1323,14 +1326,14 @@ def _calc_withdraw_one_coin(
     #   default. This is because the fee calculation will otherwise underflow.
 
     xp_imprecise: uint256[N_COINS] = xp
-    xp_correction: uint256 = xp[i] * N_COINS * token_amount // token_supply
+    xp_correction: uint256 = xp[i] * N_COINS * amount // adjusted_supply
     fee: uint256 = self._unpack_3(self.packed_fee_params)[1]  # <- self.out_fee.
 
     if xp_correction < xp_imprecise[i]:
         xp_imprecise[i] -= xp_correction
         fee = self._fee(xp_imprecise)
 
-    dD: uint256 = unsafe_div(token_amount * D, token_supply)
+    dD: uint256 = unsafe_div(amount * D, adjusted_supply)
     D_fee: uint256 = fee * dD // (2 * 10**10) + 1  # <------- Actual fee on D.
 
     # --------- Calculate `approx_fee` (assuming balanced state) in ith token.

--- a/contracts/main/Twocrypto.vy
+++ b/contracts/main/Twocrypto.vy
@@ -636,13 +636,14 @@ def remove_liquidity(
     """
     @notice This withdrawal method is very safe, does no complex math since
             tokens are withdrawn in balanced proportions. No fees are charged.
+    @dev This function inentionally does not rely on any external call to the
+            the math contract to make sure that failure in the invariant don't
+            prevent users from withdrawing their funds.
     @param amount Amount of LP tokens to burn
     @param min_amounts Minimum amounts of tokens to withdraw
     @param receiver Address to send the withdrawn tokens to
     @return uint256[3] Amount of pool tokens received by the `receiver`
     """
-    self._absorb_donation()
-
     # -------------------------------------------------------- Burn LP tokens.
 
     # TODO pack dead_supply and total_supply into a single variable.

--- a/contracts/main/Twocrypto.vy
+++ b/contracts/main/Twocrypto.vy
@@ -441,15 +441,18 @@ def _absorb_donation():
     # because `tweak_price` will check by how much the virtual price has increased
     # to compute `xcp_profit` which a donation should not affect.
 
+    donation_balances: uint256[N_COINS] = self.donation_balances
+    if donation_balances[0] + donation_balances[1] == 0:
+        return
+
+    balances: uint256[N_COINS] = self.balances
+
     # TODO this should be customizable to fit different tokens decimals and prices
     DONATION_ABSORB_AMOUNT_PER_SECOND: uint256 = 10**15
 
     # Update donations clock
     elapsed: uint256 = block.timestamp - self.last_donation_absorb_timestamp
     self.last_donation_absorb_timestamp = block.timestamp
-
-    balances: uint256[N_COINS] = self.balances
-    donation_balances: uint256[N_COINS] = self.donation_balances
 
     # Absorb donations linearly, releasing a constant amount per second.
     for i: uint256 in range(N_COINS):

--- a/contracts/main/Twocrypto.vy
+++ b/contracts/main/Twocrypto.vy
@@ -466,8 +466,12 @@ def _absorb_donation():
     # TODO this should be customizable to fit different tokens decimals and prices
     DONATION_ABSORB_AMOUNT_PER_SECOND: uint256 = 10**15
 
-    # Update donations clock
     elapsed: uint256 = block.timestamp - self.last_donation_absorb_timestamp
+    # Early return if absorption is attempted multiple times in the same block (or
+    # multiple blocks where block timestamp is the same).
+    if elapsed == 0:
+        return
+    # Update donations clock
     self.last_donation_absorb_timestamp = block.timestamp
 
     # Absorb donations linearly, releasing a constant amount per second.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ dependencies = [
 ]
 
 [tool.uv.sources]
-titanoboa = { git = "https://github.com/vyperlang/titanoboa.git", rev = "a8d5a6cd61632dbcb8f7c472974efa72decbe1b0" }
+titanoboa = { git = "https://github.com/vyperlang/titanoboa.git", rev = "e17baac9e5ef4ba9f43e3bae785a10616d35957a" }
 
 [tool.uv]
 dev-dependencies = [

--- a/tests/stateful/test_stateful.py
+++ b/tests/stateful/test_stateful.py
@@ -4,8 +4,26 @@ from hypothesis.stateful import precondition, rule
 from hypothesis.strategies import data, floats, integers, sampled_from
 from stateful_base import StatefulBase
 
-from tests.utils.constants import MAX_A, MAX_GAMMA, MIN_A, MIN_GAMMA, UNIX_DAY
+from tests.utils.constants import MAX_A, MAX_GAMMA, MIN_A, MIN_GAMMA, N_COINS, UNIX_DAY
 from tests.utils.strategies import address
+
+
+class DonationStateful(StatefulBase):
+    @rule(data=data(), user=address)
+    def donate_rule(self, data, user):
+        note("[DONATION]")
+        amounts = [0] * N_COINS
+
+        for i in range(N_COINS):
+            liquidity = self.pool.balances(i)
+
+            amounts[i] = data.draw(
+                integers(min_value=min(1, liquidity // 10_000), max_value=liquidity // 10),
+                label=f"donation amount {i}",
+            )
+
+        self.donate(amounts)
+        note("[SUCCESS]")
 
 
 class OnlySwapStateful(StatefulBase):
@@ -320,6 +338,7 @@ class RampingStateful(ImbalancedLiquidityStateful):
 
 
 TestOnlySwap = OnlySwapStateful.TestCase
+TestDonation = DonationStateful.TestCase
 TestUpOnlyLiquidity = UpOnlyLiquidityStateful.TestCase
 TestOnlyBalancedLiquidity = OnlyBalancedLiquidityStateful.TestCase
 TestImbalancedLiquidity = ImbalancedLiquidityStateful.TestCase

--- a/tests/unitary/pool/test_donate.py
+++ b/tests/unitary/pool/test_donate.py
@@ -73,6 +73,10 @@ def test_absorbed_donation_cant_be_withdrawn(pool, coins):
 
     # we move 7 days into the future to fully absorb the donation
     boa.env.time_travel(86400 * 100000)
+    pool.internal._absorb_donation()
+    assert all(
+        pool.donation_balances(i) == 0 for i in range(N_COINS)
+    ), "donation balances should be 0"
 
     for holder, amount in lp_token_holders.items():
         pool.remove_liquidity(amount, [0] * N_COINS, sender=holder)

--- a/tests/unitary/pool/test_donate.py
+++ b/tests/unitary/pool/test_donate.py
@@ -1,0 +1,134 @@
+import math
+import boa
+import pytest
+
+from tests.unitary.utils import GodModePool
+from tests.utils.constants import N_COINS
+
+
+@pytest.fixture
+def pool(swap_with_deposit, coins):
+    return GodModePool(swap_with_deposit, coins)
+
+
+def test_donation(pool, coins):
+    DONATION_AMOUNT = [10**18, 2 * 10**18]
+
+    old_balances = [pool.balances(i) for i in range(N_COINS)]
+    old_donation_balances = [pool.donation_balances(i) for i in range(N_COINS)]
+
+    assert all(old_donation_balances) == 0, "initial donation balances should be 0"
+    assert all(old_balances) != 0, "initial balances should be greater than 0"
+
+    pool.donate(DONATION_AMOUNT)
+
+    balances = [pool.balances(i) for i in range(N_COINS)]
+    donation_balances = [pool.donation_balances(i) for i in range(N_COINS)]
+    balance_of = [coin.balanceOf(pool) for coin in coins]
+
+    for i in range(N_COINS):
+        assert balances[i] == old_balances[i], "balance should not increase after donation"
+        assert (
+            donation_balances[i] == DONATION_AMOUNT[i]
+        ), "donation balance should be equal to donation amount"
+        assert (
+            balance_of[i] == balances[i] + donation_balances[i]
+        ), "token-tracked balance should be equal to balance + donation balance"
+
+
+def test_unabsorbed_donation_cant_be_withdrawn(pool, coins):
+    DONATION_AMOUNT = [10**18, 2 * 10**18]
+    pool.donate(DONATION_AMOUNT)
+
+    for coin in coins:
+        assert coin.balanceOf(pool) > 0, "all coins should be withdrawn"
+
+    lp_token_holders = pool._storage.balanceOf.get()
+    assert len(lp_token_holders) == 1, "should only have one LP token holder"
+
+    for holder, amount in lp_token_holders.items():
+        pool.remove_liquidity(amount, [0] * N_COINS, sender=holder)
+
+    lp_token_holders = pool._storage.balanceOf.get()
+    assert len(lp_token_holders) == 0, "all LP tokens should be withdrawn"
+
+    for i in range(N_COINS):
+        assert (
+            coins[i].balanceOf(pool) == DONATION_AMOUNT[i]
+        ), "only coins left should be donate funds"
+
+
+# TODO test removal case 1
+
+
+def test_absorbed_donation_cant_be_withdrawn(pool, coins):
+    DONATION_AMOUNT = [coins[i].balanceOf(pool) for i in range(N_COINS)]
+    pool.donate(DONATION_AMOUNT)
+
+    for coin in coins:
+        assert coin.balanceOf(pool) > 0, "all coins should be withdrawn"
+
+    lp_token_holders = pool._storage.balanceOf.get()
+    assert len(lp_token_holders) == 1, "should only have one LP token holder"
+
+    # we move 7 days into the future to fully absorb the donation
+    boa.env.time_travel(86400 * 100000)
+
+    for holder, amount in lp_token_holders.items():
+        pool.remove_liquidity(amount, [0] * N_COINS, sender=holder)
+
+    lp_token_holders = pool._storage.balanceOf.get()
+    assert len(lp_token_holders) == 0, "all LP tokens should be withdrawn"
+
+    # TODO
+    for i in range(N_COINS):
+        assert math.isclose(
+            coins[i].balanceOf(pool), DONATION_AMOUNT[i], rel_tol=0.00001
+        ), "only coins left should be donate funds"
+
+
+def test_absorption(pool):
+    amount = 100 * 10**18
+    DONATION_AMOUNT = [int(amount), int(amount * 1e18 // pool.price_scale())]
+    RATE = 10**15
+    INCREASES = min(DONATION_AMOUNT[i] // RATE for i in range(N_COINS))
+
+    def absorb(seconds):
+        boa.env.time_travel(seconds=seconds)
+        pool.internal._absorb_donation()
+        return [pool.balances(0), pool.balances(1)], [
+            pool.donation_balances(0),
+            pool.donation_balances(1),
+        ]
+
+    pool.donate(DONATION_AMOUNT)
+    balances, donation_balances = absorb(0)
+    constant_sum = [balances[i] + donation_balances[i] for i in range(N_COINS)]
+    virtual_price = pool.virtual_price()
+    xcp_profit = pool.xcp_profit()
+    D = pool.D()
+    for _ in range(INCREASES):
+        new_balances, new_donation_balances = absorb(1)
+        new_D = pool.D()
+        new_virtual_price = pool.virtual_price()
+        new_xcp_profit = pool.xcp_profit()
+
+        assert new_D > D, "D should be strictly increasing"
+        assert new_virtual_price > virtual_price, "virtual price should be strictly increasing"
+        assert new_xcp_profit == xcp_profit, "xcp profit should be constant"
+        for i in reversed(range(N_COINS)):
+            assert (
+                new_balances[i] == balances[i] + RATE
+            ), "balances should increase at a constant rate"
+            assert (
+                new_donation_balances[i] == donation_balances[i] - RATE
+            ), "donation balances should decrease at a constant rate"
+            assert (
+                new_balances[i] + new_donation_balances[i] == constant_sum[i]
+            ), "sum of balances should be constant"
+
+        # Update values
+        balances, donation_balances = new_balances, new_donation_balances
+        virtual_price = new_virtual_price
+        xcp_profit = new_xcp_profit
+        D = new_D

--- a/tests/unitary/utils.py
+++ b/tests/unitary/utils.py
@@ -1,0 +1,56 @@
+import boa
+
+from tests.utils.tokens import mint_for_testing
+
+god = boa.env.generate_address()
+
+
+class GodModePool:
+    def __init__(self, instance, coins):
+        self.instance = instance
+        self.coins = coins
+        self.plotting = {}
+        for c in self.coins:
+            c.approve(self.instance, 2**256 - 1, sender=god)
+
+    def __getattr__(self, name):
+        return getattr(self.instance, name)
+
+    def donate(self, amounts, update_ema=False):
+        self.__premint_amounts(amounts)
+
+        self.instance.donate(amounts, sender=god)
+
+        if update_ema:
+            self.__update_ema()
+
+    def exchange(self, i, dx, update_ema=False):
+        if i == 0:
+            amounts = [dx, 0]
+        else:
+            amounts = [0, dx]
+        self.__premint_amounts(amounts)
+
+        dy = self.instance.exchange(i, 1 - i, dx, 0, sender=god)
+
+        if update_ema:
+            self.__update_ema()
+
+        return dy
+
+    def add_liquidity(self, amounts, update_ema=False):
+        self.__premint_amounts(amounts)
+
+        lp_tokens_received = self.instance.add_liquidity(amounts, 0, boa.env.eoa, sender=god)
+
+        if update_ema:
+            self.__update_ema()
+
+        return lp_tokens_received
+
+    def __premint_amounts(self, amounts):
+        for c, amount in zip(self.coins, amounts):
+            mint_for_testing(c, god, amount)
+
+    def __update_ema(self):
+        boa.env.time_travel(seconds=86400 * 7)

--- a/uv.lock
+++ b/uv.lock
@@ -1,4 +1,5 @@
 version = 1
+revision = 1
 requires-python = "==3.12.6"
 
 [[package]]
@@ -279,7 +280,7 @@ name = "click"
 version = "8.1.8"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "colorama", marker = "platform_system == 'Windows'" },
+    { name = "colorama", marker = "sys_platform == 'win32'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/b9/2e/0090cbf739cee7d23781ad4b89a9894a41538e4fcf4c31dcdd705b78eb8b/click-8.1.8.tar.gz", hash = "sha256:ed53c9d8990d83c2a27deae68e4ee337473f6330c040a31d4225c9574d16096a", size = 226593 }
 wheels = [
@@ -691,7 +692,7 @@ name = "ipykernel"
 version = "6.29.5"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "appnope", marker = "platform_system == 'Darwin'" },
+    { name = "appnope", marker = "sys_platform == 'darwin'" },
     { name = "comm" },
     { name = "debugpy" },
     { name = "ipython" },
@@ -1167,7 +1168,7 @@ version = "1.6.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "click" },
-    { name = "colorama", marker = "platform_system == 'Windows'" },
+    { name = "colorama", marker = "sys_platform == 'win32'" },
     { name = "ghp-import" },
     { name = "jinja2" },
     { name = "markdown" },
@@ -1622,8 +1623,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/39/1b/d0b013bf7d1af7cf0a6a4fce13f5fe5813ab225313755367b36e714a63f8/pycryptodome-3.21.0-cp36-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:18caa8cfbc676eaaf28613637a89980ad2fd96e00c564135bf90bc3f0b34dd93", size = 2254397 },
     { url = "https://files.pythonhosted.org/packages/14/71/4cbd3870d3e926c34706f705d6793159ac49d9a213e3ababcdade5864663/pycryptodome-3.21.0-cp36-abi3-win32.whl", hash = "sha256:280b67d20e33bb63171d55b1067f61fbd932e0b1ad976b3a184303a3dad22764", size = 1775641 },
     { url = "https://files.pythonhosted.org/packages/43/1d/81d59d228381576b92ecede5cd7239762c14001a828bdba30d64896e9778/pycryptodome-3.21.0-cp36-abi3-win_amd64.whl", hash = "sha256:b7aa25fc0baa5b1d95b7633af4f5f1838467f1815442b22487426f94e0d66c53", size = 1812863 },
-    { url = "https://files.pythonhosted.org/packages/25/b3/09ff7072e6d96c9939c24cf51d3c389d7c345bf675420355c22402f71b68/pycryptodome-3.21.0-pp27-pypy_73-manylinux2010_x86_64.whl", hash = "sha256:2cb635b67011bc147c257e61ce864879ffe6d03342dc74b6045059dfbdedafca", size = 1691593 },
-    { url = "https://files.pythonhosted.org/packages/a8/91/38e43628148f68ba9b68dedbc323cf409e537fd11264031961fd7c744034/pycryptodome-3.21.0-pp27-pypy_73-win32.whl", hash = "sha256:4c26a2f0dc15f81ea3afa3b0c87b87e501f235d332b7f27e2225ecb80c0b1cdd", size = 1765997 },
 ]
 
 [[package]]
@@ -2040,6 +2039,15 @@ wheels = [
 ]
 
 [[package]]
+name = "snekmate"
+version = "0.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/a5/47/33f865f94c8892e3be93eaa103289709dd373442a02dc689452b18527f62/snekmate-0.1.0.tar.gz", hash = "sha256:8446b4c1aac8bf80b5e6a7e4fe7e9b2547200fabd9577bf6e22a2e79ba88d5de", size = 94723 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/14/1c/8d5285626ee40f297cc4bf944ffcb1c4bf02c966fb34ee8c452ab9b232d7/snekmate-0.1.0-py3-none-any.whl", hash = "sha256:0f56078c4237f2f57704ec6c974378751c5f30fb2c19f406aec2f173c002ab85", size = 112946 },
+]
+
+[[package]]
 name = "sniffio"
 version = "1.3.1"
 source = { registry = "https://pypi.org/simple" }
@@ -2109,7 +2117,7 @@ wheels = [
 [[package]]
 name = "titanoboa"
 version = "0.2.5"
-source = { git = "https://github.com/vyperlang/titanoboa.git?rev=a8d5a6cd61632dbcb8f7c472974efa72decbe1b0#a8d5a6cd61632dbcb8f7c472974efa72decbe1b0" }
+source = { git = "https://github.com/vyperlang/titanoboa.git?rev=e17baac9e5ef4ba9f43e3bae785a10616d35957a#e17baac9e5ef4ba9f43e3bae785a10616d35957a" }
 dependencies = [
     { name = "eth-abi" },
     { name = "eth-account" },
@@ -2184,13 +2192,13 @@ name = "twocrypto-ng"
 version = "0.1.0"
 source = { virtual = "." }
 dependencies = [
+    { name = "snekmate" },
     { name = "titanoboa" },
     { name = "vyper" },
 ]
 
 [package.dev-dependencies]
 dev = [
-    { name = "eth-account" },
     { name = "hypothesis" },
     { name = "jupyter" },
     { name = "mamushi" },
@@ -2205,13 +2213,13 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "titanoboa", git = "https://github.com/vyperlang/titanoboa.git?rev=a8d5a6cd61632dbcb8f7c472974efa72decbe1b0" },
+    { name = "snekmate", specifier = "==0.1.0" },
+    { name = "titanoboa", git = "https://github.com/vyperlang/titanoboa.git?rev=e17baac9e5ef4ba9f43e3bae785a10616d35957a" },
     { name = "vyper", specifier = "==0.4.0" },
 ]
 
 [package.metadata.requires-dev]
 dev = [
-    { name = "eth-account", specifier = ">=0.13.4" },
     { name = "hypothesis", specifier = "==6.124.2" },
     { name = "jupyter", specifier = "==1.0.0" },
     { name = "mamushi", specifier = "==0.0.4" },


### PR DESCRIPTION
This PR reintroduces the possibility of donating funds to the pool, according to the following spec:
- Donations **are not** accessible to LPs, and can be used only for rebalancing the pool according to the logic in `tweak_price`.
- Donations are permissionless, anyone can donate at any time.
- Donations can be done using one of the tokens of the pool or both.
- Donations slowly drip over time to prevent funds from being burned too fast by volatile market conditions.
- When donation drip they increase `virtual_price` while keeping `xcp_profit` constant. This is the necessary condition to trigger a rebalance.

Everything in the spec is currently WIP and could change at any time.