### PR TITLE
test: use contracts as constants

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,6 +1,13 @@
 from pytest import fixture
 from tests.utils.god_mode import GodModePool
-
+from tests.utils.constants import (
+    MATH_DEPLOYER,
+    GAUGE_DEPLOYER,
+    POOL_DEPLOYER,
+    VIEW_DEPLOYER,
+    FACTORY_DEPLOYER,
+    ERC20_DEPLOYER,
+)
 import boa
 
 # Constants
@@ -110,43 +117,32 @@ def charlie():
 
 @fixture(scope="module")
 def coins():
-    erc20_factory = boa.load_partial("tests/mocks/ERC20Mock.vy")
-    return [erc20_factory("USD", "USD", 18), erc20_factory("BTC", "BTC", 18)]
+    return [ERC20_DEPLOYER.deploy("USD", "USD", 18), ERC20_DEPLOYER.deploy("BTC", "BTC", 18)]
 
 
 # Factory fixtures
 @fixture(scope="module")
 def math_contract(deployer):
     with boa.env.prank(deployer):
-        return boa.load("contracts/main/TwocryptoMath.vy")
+        return MATH_DEPLOYER.deploy()
 
 
 @fixture(scope="module")
-def gauge_interface():
-    return boa.load_partial("contracts/main/LiquidityGauge.vy")
-
-
-@fixture(scope="module")
-def gauge_implementation(deployer, gauge_interface):
+def gauge_implementation(deployer):
     with boa.env.prank(deployer):
-        return gauge_interface.deploy_as_blueprint()
+        return GAUGE_DEPLOYER.deploy_as_blueprint()
 
 
 @fixture(scope="module")
-def amm_interface():
-    return boa.load_partial("contracts/main/Twocrypto.vy")
-
-
-@fixture(scope="module")
-def amm_implementation(deployer, amm_interface):
+def amm_implementation(deployer):
     with boa.env.prank(deployer):
-        return amm_interface.deploy_as_blueprint()
+        return POOL_DEPLOYER.deploy_as_blueprint()
 
 
 @fixture(scope="module")
 def views_contract(deployer):
     with boa.env.prank(deployer):
-        return boa.load("contracts/main/TwocryptoView.vy")
+        return VIEW_DEPLOYER.deploy()
 
 
 @fixture(scope="module")
@@ -160,7 +156,7 @@ def factory(
     views_contract,
 ):
     with boa.env.prank(deployer):
-        factory = boa.load("contracts/main/TwocryptoFactory.vy")
+        factory = FACTORY_DEPLOYER.deploy()
         factory.initialise_ownership(fee_receiver, owner)
 
     with boa.env.prank(owner):
@@ -191,7 +187,6 @@ def params():
 @fixture(scope="module")
 def pool(
     factory,
-    amm_interface,
     coins,
     params,
     deployer,
@@ -213,7 +208,7 @@ def pool(
             params["initial_prices"][1],  # initial_price: uint256
         )
 
-    return amm_interface.at(pool)
+    return POOL_DEPLOYER.at(pool)
 
 
 @fixture(scope="module")

--- a/tests/fuzzing/conftest.py
+++ b/tests/fuzzing/conftest.py
@@ -1,11 +1,13 @@
 import boa
 import pytest
 
+from tests.utils.constants import MATH_DEPLOYER
+
 
 @pytest.fixture(scope="module")
 def math_optimized(deployer):
     with boa.env.prank(deployer):
-        return boa.load("contracts/main/TwocryptoMath.vy")
+        return MATH_DEPLOYER.deploy()
 
 
 @pytest.fixture(scope="module")

--- a/tests/stateful/stateful_base.py
+++ b/tests/stateful/stateful_base.py
@@ -12,14 +12,8 @@ from hypothesis.stateful import (
 )
 from hypothesis.strategies import integers
 
-from tests.utils.constants import UNIX_DAY
+from tests.utils.constants import UNIX_DAY, FACTORY_DEPLOYER, ERC20_DEPLOYER
 from tests.utils.strategies import address, pool_from_preset
-
-boa.load_partial("contracts/main/TwocryptoFactory.vy")
-boa.load_partial("tests/mocks/ERC20Mock.vy")
-
-factory = boa.load_partial("contracts/main/TwocryptoFactory.vy")
-ERC20 = boa.load_partial("tests/mocks/ERC20Mock.vy")
 
 
 class StatefulBase(RuleBasedStateMachine):
@@ -57,7 +51,7 @@ class StatefulBase(RuleBasedStateMachine):
         self.total_supply = 0
 
         # caching coins here for easier access
-        self.coins = [ERC20.at(pool.coins(i)) for i in range(2)]
+        self.coins = [ERC20_DEPLOYER.at(pool.coins(i)) for i in range(2)]
 
         # these balances should follow the pool balances
         self.balances = [0, 0]
@@ -76,8 +70,8 @@ class StatefulBase(RuleBasedStateMachine):
 
         self.swapped_once = False
 
-        self.fee_receiver = factory.at(pool.factory()).fee_receiver()
-        self.admin = factory.at(pool.factory()).admin()
+        self.fee_receiver = FACTORY_DEPLOYER.at(pool.factory()).fee_receiver()
+        self.admin = FACTORY_DEPLOYER.at(pool.factory()).admin()
 
         # figure out the amount of the second token for a balanced deposit
         balanced_amounts = self.get_balanced_deposit_amounts(amount)

--- a/tests/unitary/factory/test_deploy_pool.py
+++ b/tests/unitary/factory/test_deploy_pool.py
@@ -1,15 +1,15 @@
 import boa
 import pytest
 
+from tests.utils.constants import FACTORY_DEPLOYER
+
 ZERO_ADDRESS = boa.eval("empty(address)")
 
 
 @pytest.fixture(scope="module")
 def empty_factory(deployer, fee_receiver, owner):
     with boa.env.prank(deployer):
-        factory = boa.load(
-            "contracts/main/TwocryptoFactory.vy",
-        )
+        factory = FACTORY_DEPLOYER.deploy()
 
     assert factory.admin() == ZERO_ADDRESS
     assert factory.fee_receiver() == ZERO_ADDRESS
@@ -30,9 +30,7 @@ def test_deployer_cannot_set_ownership_twice(empty_factory, deployer):
 
 def test_nondeployer_cannot_set_ownership(deployer):
     with boa.env.prank(deployer):
-        factory = boa.load(
-            "contracts/main/TwocryptoFactory.vy",
-        )
+        factory = FACTORY_DEPLOYER.deploy()
 
     with boa.env.prank(boa.env.generate_address()), boa.reverts():
         factory.initialise_ownership(boa.env.generate_address(), boa.env.generate_address())

--- a/tests/utils/constants.py
+++ b/tests/utils/constants.py
@@ -3,24 +3,65 @@ Constants often used for testing.
 
 These cannot be used as fixtures because they are often
 used as bounds for fuzzing (outside of the test functions).
+
+This file also makes sure that constants with the same name
+are consistent across different contracts.
 """
 
-# TODO use values from actual contracts once this:
-# https://github.com/vyperlang/titanoboa/issues/196
-# is implmented.
-N_COINS = 2
+import boa
 
-MIN_GAMMA = 10**10
-MAX_GAMMA_SMALL = 2 * 10**16
-MAX_GAMMA = 199 * 10**15  # 1.99 * 10**17
+MATH_DEPLOYER = boa.load_partial("contracts/main/TwocryptoMath.vy")
+VIEW_DEPLOYER = boa.load_partial("contracts/main/TwocryptoView.vy")
+FACTORY_DEPLOYER = boa.load_partial("contracts/main/TwocryptoFactory.vy")
+POOL_DEPLOYER = boa.load_partial("contracts/main/Twocrypto.vy")
+GAUGE_DEPLOYER = boa.load_partial("contracts/main/LiquidityGauge.vy")
+ERC20_DEPLOYER = boa.load_partial("tests/mocks/ERC20Mock.vy")
 
-A_MULTIPLIER = 10000
-MIN_A = N_COINS**N_COINS * A_MULTIPLIER / 10
-MAX_A = N_COINS**N_COINS * A_MULTIPLIER * 1000
+assert (
+    POOL_DEPLOYER._constants.N_COINS
+    == MATH_DEPLOYER._constants.N_COINS
+    == FACTORY_DEPLOYER._constants.N_COINS
+    == VIEW_DEPLOYER._constants.N_COINS
+), "N_COINS mismatch"
+
+N_COINS = POOL_DEPLOYER._constants.N_COINS
+
+assert (
+    POOL_DEPLOYER._constants.MIN_GAMMA == MATH_DEPLOYER._constants.MIN_GAMMA
+), "MIN_GAMMA mismatch"
+
+MIN_GAMMA = POOL_DEPLOYER._constants.MIN_GAMMA
+
+assert (
+    POOL_DEPLOYER._constants.MAX_GAMMA == MATH_DEPLOYER._constants.MAX_GAMMA
+), "MAX_GAMMA mismatch"
+
+MAX_GAMMA = POOL_DEPLOYER._constants.MAX_GAMMA
+
+MAX_GAMMA_SMALL = MATH_DEPLOYER._constants.MAX_GAMMA_SMALL
+
+assert (
+    POOL_DEPLOYER._constants.A_MULTIPLIER
+    == MATH_DEPLOYER._constants.A_MULTIPLIER
+    == FACTORY_DEPLOYER._constants.A_MULTIPLIER
+), "A_MULTIPLIER mismatch"
+
+A_MULTIPLIER = POOL_DEPLOYER._constants.A_MULTIPLIER
+
+assert POOL_DEPLOYER._constants.MIN_A == MATH_DEPLOYER._constants.MIN_A, "MIN_A mismatch"
+
+MIN_A = POOL_DEPLOYER._constants.MIN_A
+
+assert POOL_DEPLOYER._constants.MAX_A == MATH_DEPLOYER._constants.MAX_A, "MAX_A mismatch"
+
+MAX_A = POOL_DEPLOYER._constants.MAX_A
 
 UNIX_DAY = 86400
 
-MIN_FEE = 5 * 10**5
-MAX_FEE = 10 * 10**9
+MIN_FEE = POOL_DEPLOYER._constants.MIN_FEE
 
-MIN_RAMP_TIME = 86400
+assert POOL_DEPLOYER._constants.MAX_FEE == FACTORY_DEPLOYER._constants.MAX_FEE, "MAX_FEE mismatch"
+
+MAX_FEE = POOL_DEPLOYER._constants.MAX_FEE
+
+MIN_RAMP_TIME = POOL_DEPLOYER._constants.MIN_RAMP_TIME


### PR DESCRIPTION
* Constants used in testing are not hardcoded anymore but they directly point to constants in the contracts.
* Constants with the same name that appear in multiple contracts are now tested for consistency
* `boa.load_partial` results for common contracts is now stored in `test.utils.constants`