### PR TITLE
ci: add venom as optional check

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -8,6 +8,7 @@ env:
 
 jobs:
   tests:
+    name: ${{ matrix.folder }} (${{ matrix.venom.name }})
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -15,7 +16,10 @@ jobs:
           - "tests/unitary"
           - "tests/stateful"
           - "tests/fuzzing"
-#          - "tests/integration"
+        venom:
+          - { name: "standard mode", value: false }
+          - { name: "venom mode", value: true }
+    continue-on-error: ${{ matrix.venom.value }}
     steps:
       - name: Checkout repo
         uses: actions/checkout@v4
@@ -39,5 +43,12 @@ jobs:
       - name: Install Requirements
         run: uv sync --extra=dev
 
-      - name: Run tests in ${{ matrix.folder }}
-        run: uv run pytest ${{ matrix.folder }} -n auto
+      - name: Install Nightly Vyper if Venom is enabled
+        if: ${{ matrix.venom.value }}
+        run: |
+          uv pip install --force-reinstall 'git+https://github.com/vyperlang/vyper.git@master#egg=vyper'
+
+      - name: Run tests
+        run: |
+          export VENOM=${{ matrix.venom.value }}
+          uv run pytest ${{ matrix.folder }} -n auto

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ dependencies = [
 ]
 
 [tool.uv.sources]
-titanoboa = { git = "https://github.com/vyperlang/titanoboa.git", rev = "3e8bc3a29c0d837e99ab666649e77acccf88d494" }
+titanoboa = { git = "https://github.com/vyperlang/titanoboa.git", rev = "c098714a76d9b983e0dda5b2b1954f19d5dd6478" }
 
 [tool.uv]
 dev-dependencies = [

--- a/tests/utils/constants.py
+++ b/tests/utils/constants.py
@@ -9,6 +9,7 @@ are consistent across different contracts.
 """
 
 import boa
+import os
 
 # TODO move this to deployers.py
 MATH_DEPLOYER = boa.load_partial("contracts/main/TwocryptoMath.vy")
@@ -18,6 +19,13 @@ POOL_DEPLOYER = boa.load_partial("contracts/main/Twocrypto.vy")
 GAUGE_DEPLOYER = boa.load_partial("contracts/main/LiquidityGauge.vy")
 ERC20_DEPLOYER = boa.load_partial("tests/mocks/ERC20Mock.vy")
 
+# Set venom flag based on CI environment variable, default to False for local development
+venom_enabled = os.getenv("VENOM", False) == "true"
+
+compiler_flags = {
+    "experimental_codegen": venom_enabled,
+}
+
 # TODO this should be tested from twocrypto directly
 # temporary workaround till https://github.com/vyperlang/titanoboa/issues/393 is fixed
 packing_utils = boa.load("contracts/main/packing_utils.vy")
@@ -26,7 +34,6 @@ PARAMS_DEPLOYER = boa.load_partial("contracts/main/params.vy")
 
 c = boa.load_partial("contracts/main/constants.vy")
 
-# TODO use constants vyper module
 N_COINS = c._constants.N_COINS
 MIN_GAMMA = c._constants.MIN_GAMMA
 MAX_GAMMA = c._constants.MAX_GAMMA


### PR DESCRIPTION
This PR adds testing against code that is compiled using venom, Vyper's new IR.

While Venom is still experimental and we don't use it in production this helps the Vyper team spot bugs in the IR and supports its development.

Also this bumps boa to a more recent version that contains fixes for Venom execution.