### PR TITLE
refactor: move constants to a separte module

### DIFF
--- a/contracts/main/TwocryptoFactory.vy
+++ b/contracts/main/TwocryptoFactory.vy
@@ -1,4 +1,4 @@
-# pragma version ~=0.4.1
+# pragma version 0.4.1
 """
 @title TwocryptoFactory
 @author Curve.Fi

--- a/contracts/main/constants.vy
+++ b/contracts/main/constants.vy
@@ -1,0 +1,23 @@
+N_COINS: constant(uint256) = 2
+WAD: constant(uint256) = 10**18
+
+# A and gamma
+MIN_GAMMA: constant(uint256) = 10**10
+MAX_GAMMA_SMALL: constant(uint256) = 2 * 10**16
+MAX_GAMMA: constant(uint256) = 199 * 10**15 # 1.99 * 10**17
+
+A_MULTIPLIER: constant(uint256) = 10000
+MIN_A: constant(uint256) = N_COINS**N_COINS * A_MULTIPLIER // 10
+MAX_A: constant(uint256) = N_COINS**N_COINS * A_MULTIPLIER * 1000
+
+# Ramping constants
+MIN_RAMP_TIME: constant(uint256) = 86400
+MAX_A_CHANGE: constant(uint256) = 10
+MAX_GAMMA_CHANGE: constant(uint256) = 10
+
+# Fee constants
+ADMIN_FEE: public(constant(uint256)) = 5 * 10**9  # 50% of the fee
+MIN_FEE: constant(uint256) = 5 * 10**5  # 0.5 BPS.
+MAX_FEE: constant(uint256) = 10**10
+# TODO explain where this is used and why
+NOISE_FEE: constant(uint256) = 10**5  # 0.1 BPS.

--- a/tests/utils/constants.py
+++ b/tests/utils/constants.py
@@ -24,15 +24,17 @@ packing_utils = boa.load("contracts/main/packing_utils.vy")
 # temporary workaround till https://github.com/vyperlang/titanoboa/issues/394 is fixed
 PARAMS_DEPLOYER = boa.load_partial("contracts/main/params.vy")
 
+c = boa.load_partial("contracts/main/constants.vy")
+
 # TODO use constants vyper module
-N_COINS = POOL_DEPLOYER._constants.N_COINS
-MIN_GAMMA = PARAMS_DEPLOYER._constants.MIN_GAMMA
-MAX_GAMMA = PARAMS_DEPLOYER._constants.MAX_GAMMA
-MAX_GAMMA_SMALL = MATH_DEPLOYER._constants.MAX_GAMMA_SMALL
-A_MULTIPLIER = PARAMS_DEPLOYER._constants.A_MULTIPLIER
-MIN_A = PARAMS_DEPLOYER._constants.MIN_A
-MAX_A = PARAMS_DEPLOYER._constants.MAX_A
+N_COINS = c._constants.N_COINS
+MIN_GAMMA = c._constants.MIN_GAMMA
+MAX_GAMMA = c._constants.MAX_GAMMA
+MAX_GAMMA_SMALL = c._constants.MAX_GAMMA_SMALL
+A_MULTIPLIER = c._constants.A_MULTIPLIER
+MIN_A = c._constants.MIN_A
+MAX_A = c._constants.MAX_A
 UNIX_DAY = 86400
-MIN_FEE = PARAMS_DEPLOYER._constants.MIN_FEE
-MAX_FEE = PARAMS_DEPLOYER._constants.MAX_FEE
-MIN_RAMP_TIME = PARAMS_DEPLOYER._constants.MIN_RAMP_TIME
+MIN_FEE = c._constants.MIN_FEE
+MAX_FEE = c._constants.MAX_FEE
+MIN_RAMP_TIME = c._constants.MIN_RAMP_TIME


### PR DESCRIPTION
If you are thinking it would be much better to import constants directly by doing:

```vyper
from constants import N_COINS
```

I agree with you! Problem is as of now this is [not yet possible in vyper](https://github.com/vyperlang/vyper/issues/4291#issuecomment-2786698387).


I've also renamed `PRECISION` to `WAD` because adding the `c.` prefix makes it a bit too long.

[Why I picked WAD
](https://ethereum.stackexchange.com/questions/27101/what-does-wadstand-for)
> A wad is a decimal number with 18 digits of precision that is being represented as an integer.