### PR TITLE
feat: admin fee setter

### DIFF
--- a/contracts/main/Twocrypto.vy
+++ b/contracts/main/Twocrypto.vy
@@ -1339,6 +1339,10 @@ def _is_ramping() -> bool:
     """
     return self.future_A_gamma_time > block.timestamp
 
+@internal
+def _check_admin():
+    assert msg.sender == staticcall factory.admin(), "only owner"
+
 @view
 @internal
 def _A_gamma() -> uint256[2]:
@@ -1970,7 +1974,7 @@ def ramp_A_gamma(
     @param future_gamma The future gamma value.
     @param future_time The timestamp at which the ramping will end.
     """
-    assert msg.sender == staticcall factory.admin(), "only owner"
+    self._check_admin()
     assert not self._is_ramping(), "ramp undergoing"
     assert future_time > block.timestamp + MIN_RAMP_TIME - 1, "ramp time<min"
 
@@ -2015,7 +2019,7 @@ def stop_ramp_A_gamma():
     @notice Stop Ramping A and gamma parameters immediately.
     @dev Only accessible by factory admin.
     """
-    assert msg.sender == staticcall factory.admin(), "only owner"
+    self._check_admin()
 
     A_gamma: uint256[2] = self._A_gamma()
     current_A_gamma: uint256 = A_gamma[0] << 128
@@ -2050,7 +2054,7 @@ def apply_new_parameters(
     @param _new_adjustment_step The new adjustment step.
     @param _new_ma_time The new ma time. ma_time is time_in_seconds/ln(2).
     """
-    assert msg.sender == staticcall factory.admin(), "only owner"
+    self._check_admin()
 
     # ----------------------------- Set fee params ---------------------------
 
@@ -2112,14 +2116,14 @@ def apply_new_parameters(
 
 @external
 def set_donation_duration(duration: uint256):
-    assert msg.sender == staticcall factory.admin(), "only owner"
+    self._check_admin()
 
     self.donation_duration = duration
     log SetDonationDuration(duration=duration)
 
 @external
 def set_max_donation_ratio(ratio: uint256):
-    assert msg.sender == staticcall factory.admin(), "only owner"
+    self._check_admin()
 
     self.max_donation_ratio = ratio
     log SetMaxDonationRatio(ratio=ratio)

--- a/tests/unitary/pool/test_donation.py
+++ b/tests/unitary/pool/test_donation.py
@@ -189,7 +189,7 @@ def test_remove_liquidity_isnt_affected_by_donations(gm_pool_with_liquidity):
         ), "user withdrawn tokens should be the same before and after donation"
 
 
-@pytest.xfail("Figure out if this failure is legitimate")
+@pytest.mark.xfail
 @pytest.mark.parametrize("i", range(N_COINS))
 def test_remove_liquidity_fixed_out(gm_pool_with_liquidity, i):
     pool = gm_pool_with_liquidity

--- a/tests/unitary/test_set_admin_fee.py
+++ b/tests/unitary/test_set_admin_fee.py
@@ -1,0 +1,17 @@
+import pytest
+import boa
+
+
+@pytest.mark.parametrize("amount", [int(i * 10**10 / 4) for i in range(5)])
+def test_default_behavior(pool, factory_admin, amount):
+    pool.set_admin_fee(amount, sender=factory_admin)
+
+
+def test_only_owner(pool):
+    with boa.reverts("only owner"):
+        pool.set_admin_fee(0)
+
+
+def test_admin_fee_greater_than_max(pool, factory_admin):
+    with boa.reverts("admin_fee>MAX"):
+        pool.set_admin_fee(10**10 + 1, sender=factory_admin)


### PR DESCRIPTION
- Refactored admin checks to reduce code size by consolidating repeated revert strings into a helper method.
- Added functionality to allow the factory owner to set and change the admin fee, with an initial value of 50%.
- Included unit tests to cover the new `set_admin_fee` functionality.
- Fixed improper use of `xfail` in tests.