### PR TITLE
chore: relax python version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ name            = "twocrypto-ng"
 version         = "0.1.0"
 authors         = [{ name = "Curve.fi", email = "info@curve.fi" }]
 readme          = "README.md"
-requires-python = "==3.12.6"
+requires-python = ">=3.12"
 
 # Requirements
 dependencies = [


### PR DESCRIPTION
Having an exact version is annoying and doesn't add any particular advantage. Any Python 3.12+ version can now be used.