### PR TITLE
fix: address code style inconsistencies (Issue 6.1)

### DIFF
--- a/contracts/main/TwocryptoView.vy
+++ b/contracts/main/TwocryptoView.vy
@@ -383,19 +383,19 @@ def _prep_calc(swap: address) -> (
 
     precisions: uint256[N_COINS] = staticcall Curve(swap).precisions()
     token_supply: uint256 = staticcall Curve(swap).totalSupply()
-    xp: uint256[N_COINS] = empty(uint256[N_COINS])
+    balances: uint256[N_COINS] = empty(uint256[N_COINS])
     for k: uint256 in range(N_COINS):
-        xp[k] = staticcall Curve(swap).balances(k)
+        balances[k] = staticcall Curve(swap).balances(k)
 
     price_scale: uint256 = staticcall Curve(swap).price_scale()
 
     A: uint256 = staticcall Curve(swap).A()
     gamma: uint256 = staticcall Curve(swap).gamma()
     D: uint256 = self._calc_D_ramp(
-        A, gamma, xp, precisions, price_scale, swap
+        A, gamma, balances, precisions, price_scale, swap
     )
 
-    return xp, D, token_supply, price_scale, A, gamma, precisions
+    return balances, D, token_supply, price_scale, A, gamma, precisions
 
 
 @internal


### PR DESCRIPTION
## Summary
- Fixed code style inconsistencies as identified in audit report Issue 6.1
- Added underscore prefix to internal functions (`tweak_price` → `_tweak_price`, `mint` → `_mint`, `burnFrom` → `_burnFrom`)
- Standardized parameter naming (removed unnecessary underscores, fixed `lp_token_amount` → `token_amount`)
- Removed commented-out constants and TODO comments
- Replaced magic number `18446744073709551615` with `MAX_UINT64` constant
- Fixed bare `raise` statement to include error message
- Improved code readability by replacing `pow_mod256(N_COINS, N_COINS)` with `N_COINS ** N_COINS`
- Optimized for loop to iterate directly over array values
- Fixed misleading variable name in `_prep_calc` (`xp` → `balances`)

## Test plan
- [x] All changes are internal/cosmetic and do not affect contract behavior
- [x] Successfully compiled all modified contracts with `uv run vyper`
- [x] All unit tests pass with `uv run pytest -n 10`

Created using Claude Code