### PR TITLE
fix: change view functions to pure (6.5)

### DIFF
--- a/contracts/main/StableswapMath.vy
+++ b/contracts/main/StableswapMath.vy
@@ -70,7 +70,7 @@ def get_y(
 
 
 @external
-@view
+@pure
 def newton_D(_amp: uint256,
     gamma: uint256, # unused, present for compatibility with twocrypto
     _xp: uint256[N_COINS],
@@ -122,7 +122,7 @@ def newton_D(_amp: uint256,
 
 
 @external
-@view
+@pure
 def get_p(
     _xp: uint256[N_COINS], _D: uint256, _A_gamma: uint256[N_COINS]
 ) -> uint256:

--- a/contracts/main/Twocrypto.vy
+++ b/contracts/main/Twocrypto.vy
@@ -441,8 +441,8 @@ def exchange_received(
     return out[0]
 
 
-@view
 @internal
+@view
 def _donation_shares() -> uint256:
     donation_shares: uint256 = self.donation_shares
     # Time passed since the last donation absorption.
@@ -1269,11 +1269,12 @@ def _is_ramping() -> bool:
     return self.future_A_gamma_time > block.timestamp
 
 @internal
+@view
 def _check_admin():
     assert msg.sender == staticcall factory.admin(), "only owner"
 
-@view
 @internal
+@view
 def _A_gamma() -> uint256[2]:
     t1: uint256 = self.future_A_gamma_time
 
@@ -1377,8 +1378,8 @@ def _xcp(D: uint256, price_scale: uint256) -> uint256:
     return D * PRECISION // N_COINS // isqrt(PRECISION * price_scale)
 
 
-@view
 @internal
+@view
 def _calc_token_fee(amounts: uint256[N_COINS], xp: uint256[N_COINS], donation: bool = False) -> uint256:
     if donation:
         # Donation fees are 0, but NOISE_FEE is required for numerical stability

--- a/contracts/main/TwocryptoView.vy
+++ b/contracts/main/TwocryptoView.vy
@@ -399,7 +399,7 @@ def _prep_calc(swap: address) -> (
 
 
 @internal
-@view
+@pure
 def _unpack_3(_packed: uint256) -> uint256[3]:
     """
     @notice Unpacks a uint256 into 3 integers (values must be <= 10**18)


### PR DESCRIPTION
## Summary
- Changed `StableswapMath.newton_D()` from `@view` to `@pure`
- Changed `StableswapMath.get_p()` from `@view` to `@pure`
- Changed `TwocryptoView._unpack_3()` from `@view` to `@pure`

These functions don't read contract state and only perform calculations on input parameters.

## Test plan
- [x] All contracts compile successfully
- [x] Unit tests pass

Created using Claude Code