### PR TITLE
fix: Add donation flag to AddLiquidity event (Issue 6.8)

### DIFF
--- a/contracts/main/Twocrypto.vy
+++ b/contracts/main/Twocrypto.vy
@@ -77,6 +77,7 @@ event AddLiquidity:
     fee: uint256
     token_supply: uint256
     price_scale: uint256
+    is_donation: bool
 
 event RemoveLiquidity:
     provider: indexed(address)
@@ -582,7 +583,8 @@ def add_liquidity(
         token_amounts=amounts_received,
         fee=d_token_fee,
         token_supply=token_supply,
-        price_scale=price_scale
+        price_scale=price_scale,
+        is_donation=donation
     )
 
     return d_token


### PR DESCRIPTION
## Summary
- Added `is_donation` boolean field to the `AddLiquidity` event to clearly indicate whether liquidity is being added as a donation

## Changes
- Updated the `AddLiquidity` event definition to include `is_donation: bool` field
- Modified the event emission in `add_liquidity()` to pass the `donation` parameter value

This change improves event clarity and allows off-chain applications to easily distinguish between regular liquidity additions and donations.

## Test plan
- [x] Contract compiles successfully with `uv run vyper`
- [x] All unit tests pass: 227 passed

Created using Claude Code