### PR TITLE
fix: Correct approx_fee scaling in RemoveLiquidityImbalance event (Issue 6.9)

### DIFF
--- a/contracts/main/Twocrypto.vy
+++ b/contracts/main/Twocrypto.vy
@@ -764,7 +764,7 @@ def _remove_liquidity_fixed_out(
         provider=msg.sender,
         lp_token_amount=token_amount,
         token_amounts=token_amounts,
-        approx_fee=approx_fee * token_amount // PRECISION,
+        approx_fee=approx_fee * token_amount // 10**10 + 1,
         price_scale=price_scale
     )
 


### PR DESCRIPTION
## Summary
- Fixed incorrect scaling of `approx_fee` in the `RemoveLiquidityImbalance` event emission

## Changes
- Changed scaling factor from `PRECISION` (10**18) to `10**10` to match the actual units of `approx_fee`
- Added `+ 1` for rounding up to be consistent with other fee calculations in the codebase

The `approx_fee` value returned by `_calc_token_fee()` is already scaled by 10**10, so dividing by PRECISION was incorrect and would result in a much smaller fee value being emitted.

## Test plan
- [x] Contract compiles successfully with `uv run vyper`
- [x] All unit tests pass: 227 passed

Created using Claude Code