### PR TITLE
fix: add missing sanity checks (Issue 6.13)

### DIFF
--- a/contracts/main/Twocrypto.vy
+++ b/contracts/main/Twocrypto.vy
@@ -566,6 +566,7 @@ def add_liquidity(
     else:
 
         # (re)instatiating an empty pool:
+        assert not donation, "no donation on first deposit"
 
         self.D = D
         self.virtual_price = 10**18

--- a/contracts/main/TwocryptoView.vy
+++ b/contracts/main/TwocryptoView.vy
@@ -106,7 +106,7 @@ def calc_withdraw_one_coin(
 def calc_token_amount(
     amounts: uint256[N_COINS], deposit: bool, swap: address, donation: bool = False
 ) -> uint256:
-    
+
     # Sanity check: donation only valid for deposits
     assert not donation or deposit, "donation requires deposit"
 
@@ -148,7 +148,7 @@ def calc_fee_withdraw_one_coin(
 def calc_fee_token_amount(
     amounts: uint256[N_COINS], deposit: bool, swap: address, donation: bool = False
 ) -> uint256:
-    
+
     # Sanity check: donation only valid for deposits
     assert not donation or deposit, "donation requires deposit"
 

--- a/contracts/main/TwocryptoView.vy
+++ b/contracts/main/TwocryptoView.vy
@@ -106,6 +106,9 @@ def calc_withdraw_one_coin(
 def calc_token_amount(
     amounts: uint256[N_COINS], deposit: bool, swap: address, donation: bool = False
 ) -> uint256:
+    
+    # Sanity check: donation only valid for deposits
+    assert not donation or deposit, "donation requires deposit"
 
     d_token: uint256 = 0
     amountsp: uint256[N_COINS] = empty(uint256[N_COINS])
@@ -145,6 +148,9 @@ def calc_fee_withdraw_one_coin(
 def calc_fee_token_amount(
     amounts: uint256[N_COINS], deposit: bool, swap: address, donation: bool = False
 ) -> uint256:
+    
+    # Sanity check: donation only valid for deposits
+    assert not donation or deposit, "donation requires deposit"
 
     d_token: uint256 = 0
     amountsp: uint256[N_COINS] = empty(uint256[N_COINS])

--- a/tests/unitary/pool/test_donation.py
+++ b/tests/unitary/pool/test_donation.py
@@ -1,12 +1,12 @@
 import boa
 from tests.utils.constants import N_COINS
-from pytest import fixture, approx
+from pytest import fixture, approx, raises
 
 
 def test_cant_donate_on_empty_pool(gm_pool):
     assert gm_pool.donation_shares() == 0
-    gm_pool.donate([10**18, 2 * 10**18])
-    assert gm_pool.donation_shares() == 0
+    with raises(boa.BoaError, match="no donation on first deposit"):
+        gm_pool.donate([10**18, 2 * 10**18])
 
 
 @fixture()


### PR DESCRIPTION
## Summary
- Added sanity check to prevent donations on first deposit in `add_liquidity()`
- Added consistency checks in `TwocryptoView` to ensure donations can only occur during deposits

## Issue
The audit report identified missing sanity checks in several functions that could lead to inconsistent behavior:
1. Donations were allowed on the first deposit to an empty pool
2. View functions didn't validate that donations only apply to deposits

## Solution
- Added `assert not donation, "no donation on first deposit"` in `add_liquidity()` when `old_D == 0`
- Added `assert not donation or deposit, "donation requires deposit"` in both `calc_token_amount()` and `calc_fee_token_amount()` in TwocryptoView
- Updated test `test_cant_donate_on_empty_pool` to expect the assertion error

Note: Per project guidelines, we skipped the check for zero receiver without donation flag, as burning LP tokens without donation is a valid use case.

Created using Claude Code.