### PR TITLE
fix: remove unused code (Issue 6.15)

### DIFF
--- a/contracts/main/StableswapMath.vy
+++ b/contracts/main/StableswapMath.vy
@@ -12,9 +12,6 @@ from snekmate.utils import math
 # MAX_GAMMA_SMALL: constant(uint256) = 2 * 10**16
 # MAX_GAMMA: constant(uint256) = 199 * 10**15 # 1.99 * 10**17
 
-MIN_A: constant(uint256) = N_COINS**N_COINS * A_MULTIPLIER // 10
-MAX_A: constant(uint256) = N_COINS**N_COINS * A_MULTIPLIER * 1000
-
 N_COINS: constant(uint256) = 2
 A_MULTIPLIER: constant(uint256) = 10000
 

--- a/contracts/main/Twocrypto.vy
+++ b/contracts/main/Twocrypto.vy
@@ -83,14 +83,6 @@ event RemoveLiquidity:
     token_amounts: uint256[N_COINS]
     token_supply: uint256
 
-event RemoveLiquidityOne:
-    provider: indexed(address)
-    token_amount: uint256
-    coin_index: uint256
-    coin_amount: uint256
-    approx_fee: uint256
-    price_scale: uint256
-
 event RemoveLiquidityImbalance:
     provider: indexed(address)
     lp_token_amount: uint256
@@ -1318,14 +1310,6 @@ def _fee(xp: uint256[N_COINS]) -> uint256:
 
     # mid_fee * B + out_fee * (1 - B)
     return unsafe_div(fee_params[0] * B + fee_params[1] * (10**18 - B), 10**18)
-
-
-@internal
-@pure
-def _D_from_xcp(xcp: uint256, price_scale: uint256) -> uint256:
-    # For N_COINS=2 xcp equals to D // (N_COINS * √price_scale), this is just
-    # the inverse of the formula used in `_xcp`.
-    return xcp * N_COINS * isqrt(price_scale * PRECISION) // PRECISION
 
 
 @internal

--- a/contracts/main/TwocryptoView.vy
+++ b/contracts/main/TwocryptoView.vy
@@ -15,8 +15,6 @@ interface Curve:
     def A() -> uint256: view
     def gamma() -> uint256: view
     def price_scale() -> uint256: view
-    def price_oracle() -> uint256: view
-    def get_virtual_price() -> uint256: view
     def balances(i: uint256) -> uint256: view
     def D() -> uint256: view
     def fee_calc(xp: uint256[N_COINS]) -> uint256: view
@@ -43,13 +41,6 @@ interface Math:
         D: uint256,
         i: uint256,
     ) -> uint256[2]: view
-    def newton_y(
-        ANN: uint256,
-        gamma: uint256,
-        x: uint256[N_COINS],
-        D: uint256,
-        i: uint256,
-    ) -> uint256: view
 
 
 N_COINS: constant(uint256) = 2

--- a/tests/utils/constants.py
+++ b/tests/utils/constants.py
@@ -61,11 +61,7 @@ assert (
 
 A_MULTIPLIER = POOL_DEPLOYER._constants.A_MULTIPLIER
 
-assert POOL_DEPLOYER._constants.MIN_A == MATH_DEPLOYER._constants.MIN_A, "MIN_A mismatch"
-
 MIN_A = POOL_DEPLOYER._constants.MIN_A
-
-assert POOL_DEPLOYER._constants.MAX_A == MATH_DEPLOYER._constants.MAX_A, "MAX_A mismatch"
 
 MAX_A = POOL_DEPLOYER._constants.MAX_A
 


### PR DESCRIPTION
## Summary
- Removed unused `RemoveLiquidityOne` event from `Twocrypto`
- Removed unused `_D_from_xcp()` function from `Twocrypto`
- Removed unused `MIN_A` and `MAX_A` constants from `StableswapMath`
- Removed unused `price_oracle()` and `get_virtual_price()` from `Curve` interface in `TwocryptoView`
- Removed unused `newton_y()` from `Math` interface in `TwocryptoView`
- Updated tests to remove MIN_A/MAX_A validation between contracts

## Issue
The audit report identified several pieces of unused code that should be removed to improve code clarity and maintainability.

## Solution
Removed all identified unused code elements:
1. Event that was never emitted
2. Internal function that was never called
3. Constants that were not used in the math contract
4. Interface methods that don't exist in the implementation

Note: We did not remove `A_MULTIPLIER` from `TwocryptoFactory` as it was not in our scope (we don't modify TwocryptoFactory per project rules).

Created using Claude Code.