### PR TITLE
fix: handle first deposit in _calc_dtoken_nofee (Issue 6.17)

### DIFF
--- a/contracts/main/TwocryptoView.vy
+++ b/contracts/main/TwocryptoView.vy
@@ -290,12 +290,18 @@ def _calc_dtoken_nofee(
     ]
 
     D: uint256 = staticcall math.newton_D(A, gamma, xp, 0)
-    d_token: uint256 = token_supply * D // D0
+    d_token: uint256 = 0
 
-    if deposit:
-        d_token -= token_supply
+    if D0 > 0:
+        d_token = token_supply * D // D0
+        if deposit:
+            d_token -= token_supply
+        else:
+            d_token = token_supply - d_token
     else:
-        d_token = token_supply - d_token
+        # First deposit: use xcp formula to maintain initial virtual price of 1
+        # xcp = D // N_COINS // sqrt(price_scale)
+        d_token = D * PRECISION // N_COINS // isqrt(PRECISION * price_scale)
 
     return d_token, amountsp, xp
 


### PR DESCRIPTION
## Summary
- Fixed `_calc_dtoken_nofee` in TwocryptoView to handle the first deposit case when D0 == 0

## Issue
The function `_calc_dtoken_nofee` would fail with division by zero when calculating `d_token = token_supply * D // D0` during the first deposit to an empty pool (when D0 == 0).

## Solution
Added a check for D0 > 0:
- If D0 > 0: Use the normal calculation formula
- If D0 == 0 (first deposit): Use the xcp formula `D * PRECISION // N_COINS // isqrt(PRECISION * price_scale)` to maintain initial virtual price of 1

This matches the behavior in the main Twocrypto contract's `add_liquidity` function.

Created using Claude Code.