### PR TITLE
fix: make wad_exp return type explicit (Issue 6.18)

### DIFF
--- a/contracts/main/StableswapMath.vy
+++ b/contracts/main/StableswapMath.vy
@@ -147,5 +147,7 @@ def get_p(
 
 @external
 @pure
-def wad_exp(x: int256) -> int256:
-    return math._wad_exp(x)
+def wad_exp(x: int256) -> uint256:
+    # Explicitly cast the result to uint256 as wad_exp always returns positive values
+    # This avoids implicit cast confusion between int256 and uint256
+    return convert(math._wad_exp(x), uint256)


### PR DESCRIPTION
## Summary
- Changed `wad_exp` return type from `int256` to `uint256` with explicit conversion in StableswapMath

## Issue
The `wad_exp` function in StableswapMath returns `int256`, but the Twocrypto contract's Math interface expects it to return `uint256`. While the function always returns positive values (making the implicit cast safe in practice), the audit recommended making this conversion explicit to avoid confusion.

## Solution
- Changed the return type of `wad_exp` from `int256` to `uint256`
- Added explicit `convert()` call to cast the result from `math._wad_exp(x)`
- Added comments explaining that wad_exp always returns positive values

This makes the type conversion explicit and matches the interface expectation in Twocrypto.

Created using Claude Code.