### PR TITLE
fix: issue 5.6 - Incorrect Approximate Fee

### DIFF
--- a/contracts/main/Twocrypto.vy
+++ b/contracts/main/Twocrypto.vy
@@ -764,7 +764,7 @@ def _remove_liquidity_fixed_out(
         provider=msg.sender,
         lp_token_amount=token_amount,
         token_amounts=token_amounts,
-        approx_fee=approx_fee * token_amount // PRECISION,
+        approx_fee=approx_fee * token_amount // 10**10 + 1,
         price_scale=price_scale
     )
 


### PR DESCRIPTION
## Summary
- Fixed incorrect scaling of approx_fee in RemoveLiquidityImbalance event within _remove_liquidity_fixed_out()
- Changed scaling from PRECISION (10**18) to 10**10 to match other fee calculations
- Added rounding up by 1 for consistency

## Details
In `_remove_liquidity_fixed_out()`, the RemoveLiquidityImbalance event was emitting an incorrectly scaled approx_fee value. The fee was being scaled with PRECISION (10**18) instead of 10**10, which is the correct scaling factor for approx_fee throughout the codebase.

This fix ensures the emitted fee value is consistent with other fee calculations and matches the expected scaling.

Created using Claude Code.