### PR TITLE
Stateful tests fixes

### DIFF
--- a/contracts/main/Twocrypto.vy
+++ b/contracts/main/Twocrypto.vy
@@ -983,6 +983,8 @@ def tweak_price(
     last_prices: uint256 = self.last_prices
     price_scale: uint256 = self.cached_price_scale
     rebalancing_params: uint256[3] = self._unpack_3(self.packed_rebalancing_params)
+    is_ramping: bool = self._is_ramping() # store as we bump the timestamp below
+
     # Contains: allowed_extra_profit, adjustment_step, ma_time. -----^
 
     # ------------------ Update Price Oracle if needed -----------------------
@@ -1053,7 +1055,7 @@ def tweak_price(
     if virtual_price < old_virtual_price:
         # If A and gamma are being ramped, we allow the virtual price to decrease,
         # as changing the shape of the bonding curve causes losses in the pool.
-        assert self._is_ramping(), "virtual price decreased"
+        assert is_ramping, "virtual price decreased"
 
     # xcp_profit follows growth of virtual price (and goes down on ramping)
     xcp_profit: uint256 = self.xcp_profit + virtual_price - old_virtual_price
@@ -1316,7 +1318,7 @@ def _is_ramping() -> bool:
     @notice Checks if A and gamma are ramping.
     @return bool True if A and/or gamma are ramping, False otherwise.
     """
-    return self.future_A_gamma_time > block.timestamp
+    return self.future_A_gamma_time > self.last_timestamp
 
 @internal
 @view

--- a/contracts/main/Twocrypto.vy
+++ b/contracts/main/Twocrypto.vy
@@ -206,8 +206,8 @@ A_MULTIPLIER: constant(uint256) = 10000
 # Note on pool internal logic:
 # A is scaled by N_COINS in context of StableswapMath.vy
 # So A := A_true * N_COINS
-MIN_A: constant(uint256) = N_COINS**(N_COINS-1) * A_MULTIPLIER // 10
-MAX_A: constant(uint256) = N_COINS**(N_COINS-0) * A_MULTIPLIER * 1000 #relax max constraint
+MIN_A: constant(uint256) = N_COINS * A_MULTIPLIER # to avoid underflow in math (Ann - multiplier)
+MAX_A: constant(uint256) = 10_000 * A_MULTIPLIER # same as in stableswap
 MAX_PARAM_CHANGE: constant(uint256) = 10
 MIN_GAMMA: constant(uint256) = 10**10
 MAX_GAMMA: constant(uint256) = 199 * 10**15 # 1.99 * 10**17

--- a/contracts/main/TwocryptoView.vy
+++ b/contracts/main/TwocryptoView.vy
@@ -25,6 +25,7 @@ interface Curve:
     def totalSupply() -> uint256: view
     def precisions() -> uint256[N_COINS]: view
     def packed_fee_params() -> uint256: view
+    def last_timestamp() -> uint256: view
 
 
 interface Math:
@@ -158,7 +159,7 @@ def _calc_D_ramp(
 
     math: Math = staticcall Curve(swap).MATH()
     D: uint256 = staticcall Curve(swap).D()
-    if staticcall Curve(swap).future_A_gamma_time() > block.timestamp:
+    if staticcall Curve(swap).future_A_gamma_time() > staticcall Curve(swap).last_timestamp():
         _xp: uint256[N_COINS] = xp
         _xp[0] *= precisions[0]
         _xp[1] = _xp[1] * price_scale * precisions[1] // PRECISION

--- a/tests/stateful/stateful_base.py
+++ b/tests/stateful/stateful_base.py
@@ -97,7 +97,7 @@ class StatefulBase(RuleBasedStateMachine):
     def is_ramping(self) -> bool:
         """Check if the pool is currently ramping."""
 
-        return self.pool.future_A_gamma_time() > boa.env.evm.patch.timestamp
+        return self.pool.future_A_gamma_time() > self.pool.last_timestamp()
 
     def correct_decimals(self, amount: int, coin_idx: int) -> int:
         """Takes an amount that uses 18 decimals and reduces its precision"""

--- a/tests/stateful/test_stateful.py
+++ b/tests/stateful/test_stateful.py
@@ -7,6 +7,7 @@ from tests.unitary.factory.test_deploy_pool import ZERO_ADDRESS
 from tests.utils.constants import MAX_A, MAX_GAMMA, MIN_A, MIN_GAMMA, UNIX_DAY
 from tests.utils.strategies import address
 # from hypothesis import reproduce_failure
+# boa.env.evm.patch.code_size_limit = 1000000
 
 
 class OnlySwapStateful(StatefulBase):
@@ -409,8 +410,6 @@ class DonateStateful(ImbalancedLiquidityStateful):
         self.report_equilibrium()
         note("[SUCCESS]")
 
-
-# boa.env.evm.patch.code_size_limit = 1000000
 
 # --- Parallel Test Case Generation ---
 


### PR DESCRIPTION
Fixed ramping detection on the last step when block.timestamp is not enough.