### PR TITLE
feat: limit tweak_price frequency

### DIFF
--- a/contracts/main/Twocrypto.vy
+++ b/contracts/main/Twocrypto.vy
@@ -1112,8 +1112,8 @@ def tweak_price(
     # this is approximate condition that preliminary indicates readiness for rebalancing
     vp_boosted: uint256 = 10**18 * xcp // locked_supply
     assert vp_boosted >= virtual_price, "negative donation"
-    if vp_boosted  > threshold_vp + rebalancing_params[0]:
-        #             allowed_extra_profit --------^
+    if (vp_boosted  > threshold_vp + rebalancing_params[0]) and (last_timestamp < block.timestamp):
+        #        allowed_extra_profit --------^               #   ^ only rebalance once per block (first tx)
         norm: uint256 = unsafe_div(
             unsafe_mul(price_oracle, 10**18), price_scale
         )

--- a/tests/unitary/pool/test_donation_schedule.py
+++ b/tests/unitary/pool/test_donation_schedule.py
@@ -21,7 +21,9 @@ def _trigger_burn_via_exchange(pool, ratio_num=13, ratio_den=10):
     base = 100_000 * 10**18
     for k in range(8):
         dx = base * (k + 1)
+        pool.eval("self.last_timestamp = block.timestamp-1")
         pool.exchange(0, dx, update_ema=False)
+        pool.eval("self.last_timestamp = block.timestamp")
         if pool.donation_shares() < pre_s:
             return True
 
@@ -31,7 +33,10 @@ def _trigger_burn_via_exchange(pool, ratio_num=13, ratio_den=10):
     pool.eval("self.last_timestamp = block.timestamp")
     for k in range(8):
         dx = base * (k + 1)
+        pool.eval("self.last_timestamp = block.timestamp-1")
         pool.exchange(1, dx, update_ema=False)
+        pool.eval("self.last_timestamp = block.timestamp")
+        # to allow multiple rebalances in the same block
         if pool.donation_shares() < pre_s:
             return True
 
@@ -170,7 +175,7 @@ def test_time_evolution_linear_no_protection(pool_ready_with_donation):
     dt = pool.donation_duration() // 10
     target = min(new_total, snap["U"] + new_total * dt // pool.donation_duration())
     boa.env.time_travel(seconds=dt)
-    assert _read_donation_shares(pool, False) == target
+    assert abs(_read_donation_shares(pool, False) - target) <= 10
 
 
 def test_extreme_burn_minimal_rounding(pool_ready_with_donation):


### PR DESCRIPTION
For security reasons we limit price_scale adjustment to be only possible in first transaction in the block.