### PR TITLE
V3 admin fee refactor

### DIFF
--- a/contracts/main/Twocrypto.vy
+++ b/contracts/main/Twocrypto.vy
@@ -155,7 +155,7 @@ event SetDonationParameters:
     donation_shares_max_ratio: uint256
 
 event SetFeeParameters:
-    lp_profit_fraction: uint256
+    reserved_profit_fraction: uint256
     admin_fee: uint256
 
 event SetPolicyContract:
@@ -228,8 +228,9 @@ packed_rebalancing_params: public(uint256)  # <---------- Contains rebalancing
 # Fee params that determine dynamic fees:
 packed_fee_params: public(uint256)  # <---- Packs mid_fee, out_fee, fee_gamma.
 
-# Split between rebalancing budget and admin/LP share, with 10**10 precision.
-lp_profit_fraction: public(uint256)
+# Gross profit fraction reserved from rebalancing, with 10**10 precision.
+# This bucket is split between admin and LPs by `admin_fee`.
+reserved_profit_fraction: public(uint256)
 
 # DAO share of LP/DAO fee split with 10**10 precision. The rest goes to LPs.
 admin_fee: public(uint256)
@@ -297,8 +298,8 @@ def __init__(
     MATH = Math(empty(address))
     self.POLICY = Policy(empty(address))
 
-    # Split between rebalancing budget and admin/LP share
-    self.lp_profit_fraction = FEE_PRECISION * 50 // 100
+    # Gross profit bucket reserved from rebalancing and split between admin/LPs.
+    self.reserved_profit_fraction = FEE_PRECISION * 50 // 100
 
     # Split between DAO and LPs of the admin/LP share of fees.
     self.admin_fee = FEE_PRECISION * 50 // 100
@@ -640,7 +641,7 @@ def add_liquidity(
 
         if not donation:
             admin_d_token_fee: uint256 = unsafe_div(
-                d_token_fee * self.lp_profit_fraction * self.admin_fee,
+                d_token_fee * self.reserved_profit_fraction * self.admin_fee,
                 FEE_PRECISION * FEE_PRECISION
             )
             if admin_d_token_fee > 0:
@@ -910,7 +911,7 @@ def _remove_liquidity_fixed_out(
     j: uint256 = 1 - i
     d_token_fee: uint256 = approx_fee * token_amount // FEE_PRECISION + 1
     admin_d_token_fee: uint256 = unsafe_div(
-        d_token_fee * self.lp_profit_fraction * self.admin_fee,
+        d_token_fee * self.reserved_profit_fraction * self.admin_fee,
         FEE_PRECISION * FEE_PRECISION
     )
     if admin_d_token_fee > 0:
@@ -1067,7 +1068,7 @@ def _exchange(
     y -= dy
 
     admin_fee_amount: uint256 = unsafe_div(
-        fee * self.lp_profit_fraction * self.admin_fee,
+        fee * self.reserved_profit_fraction * self.admin_fee,
         FEE_PRECISION * FEE_PRECISION
     )
     if admin_fee_amount > 0:
@@ -1202,16 +1203,55 @@ def tweak_price(
 
     # ------------ Rebalance liquidity if there's enough profits to adjust it:
     #
-    # Mathematical basis for rebalancing condition:
-    # 1. xcp_profit grows after virtual price, total growth since launch = (xcp_profit − 1)
-    # 2. We reserve lp_profit_fraction of the growth for LPs, rest is used to rebalance the pool.
+    # In this version, admin fees are booked immediately into token-denominated
+    # admin_balances and removed from AMM-owned balances. VP and xcp_profit
+    # therefore observe net-of-admin growth.
+    #
+    # `reserved_profit_fraction` keeps legacy gross-profit semantics. Let:
+    #
+    #   gross_profit = total fee/profit growth before admin is removed
+    #   reserve_fraction = reserved_profit_fraction
+    #   admin_fraction = admin_fee
+    #
+    # Then the split is:
+    #
+    #   reserved bucket  = gross_profit * reserve_fraction
+    #   rebalance bucket = gross_profit * (1 - reserve_fraction)
+    #   admin tokens     = gross_profit * reserve_fraction * admin_fraction
+    #   LP reserve       = gross_profit * reserve_fraction * (1 - admin_fraction)
+    #
+    # Since admin tokens are already outside VP/xcp, xcp_profit sees:
+    #
+    #   net_growth = gross_profit * (1 - reserve_fraction * admin_fraction)
+    #
+    # The threshold must reserve only the LP part still inside AMM accounting:
+    #
+    #   net_lp_reserve_fraction =
+    #       reserve_fraction * (1 - admin_fraction) /
+    #       (1 - reserve_fraction * admin_fraction)
+    #
+    # This preserves the legacy semantics where reserved profit is further
+    # split between admin and LPs by admin_fee. It does not account admin fees
+    # in VP units; it only maps the legacy gross configured reserve onto
+    # net-of-admin xcp_profit growth.
 
-    # Rebalancing condition basis:
-    #   virtual_price > 1 + (xcp_profit - 1) * lp_profit_fraction
+    reserved_fraction: uint256 = self.reserved_profit_fraction
+    admin_fee: uint256 = self.admin_fee
+    denominator: uint256 = FEE_PRECISION * FEE_PRECISION - reserved_fraction * admin_fee
 
-    threshold_vp: uint256 = PRECISION + (
-        unsafe_sub(max(xcp_profit, PRECISION), PRECISION) * self.lp_profit_fraction // FEE_PRECISION
-    )
+    profit_growth: uint256 = unsafe_sub(max(xcp_profit, PRECISION), PRECISION)
+    threshold_vp: uint256 = PRECISION + profit_growth
+    if denominator > 0:
+        # If admin_fee is zero, denominator is FEE_PRECISION**2 and this
+        # reduces to profit_growth * reserved_fraction.
+        threshold_vp = PRECISION + unsafe_div(
+            profit_growth * reserved_fraction * (FEE_PRECISION - admin_fee),
+            denominator
+        )
+    # If reserved_fraction == admin_fee == FEE_PRECISION, all gross profit is
+    # booked to admin_balances and no net xcp growth remains. Keep the full
+    # threshold above to preserve "all profit reserved, no rebalancing" semantics.
+
     # user_supply < total_supply => vp_boosted > virtual_price
     # by not accounting for donation shares, virtual_price is boosted leading to rebalance trigger
     # this is approximate condition that preliminary indicates readiness for rebalancing
@@ -2343,13 +2383,13 @@ def set_donation_parameters(
 
 
 @internal
-def _set_fee_parameters(lp_profit_fraction: uint256, admin_fee: uint256):
-    assert lp_profit_fraction <= FEE_PRECISION  # dev: "lp profit fraction above 1e10"
+def _set_fee_parameters(reserved_profit_fraction: uint256, admin_fee: uint256):
+    assert reserved_profit_fraction <= FEE_PRECISION  # dev: "reserved profit fraction above 1e10"
     assert admin_fee <= MAX_ADMIN_FEE  # dev: "admin fee above max"
 
     self.admin_fee = admin_fee
-    self.lp_profit_fraction = lp_profit_fraction
-    log SetFeeParameters(lp_profit_fraction=lp_profit_fraction, admin_fee=admin_fee)
+    self.reserved_profit_fraction = reserved_profit_fraction
+    log SetFeeParameters(reserved_profit_fraction=reserved_profit_fraction, admin_fee=admin_fee)
 
 
 @internal
@@ -2386,7 +2426,7 @@ def _set_allowlist(add: DynArray[address, 16], remove: DynArray[address, 16]):
 @external
 @nonreentrant
 def initialize(
-    lp_profit_fraction: uint256,
+    reserved_profit_fraction: uint256,
     admin_fee: uint256,
     policy: Policy,
     initial_price: uint256,
@@ -2394,8 +2434,8 @@ def initialize(
 ):
     """
     @notice One-time post-deploy initialization for init-required pools.
-    @param lp_profit_fraction The LP/DAO share of profits, with 10**10 precision.
-    @param admin_fee The DAO share of the LP/DAO bucket, with 10**10 precision.
+    @param reserved_profit_fraction Gross profit share reserved from rebalancing, with 10**10 precision.
+    @param admin_fee The DAO share of the reserved profit bucket, with 10**10 precision.
     @param policy Optional policy contract to attach.
     @param initial_price Price scale and oracle seed to use before first liquidity.
     @param allowlist_add Initial LP allowlist entries. Any non-empty address
@@ -2411,7 +2451,7 @@ def initialize(
     assert initial_price > 10**6 and initial_price < 10**30, "initial price out of bound"
 
     # Set fee params
-    self._set_fee_parameters(lp_profit_fraction, admin_fee)
+    self._set_fee_parameters(reserved_profit_fraction, admin_fee)
     # Set policy
     self._set_policy(policy)
     self.cached_price_scale = initial_price
@@ -2430,14 +2470,14 @@ def initialize(
 
 @external
 @nonreentrant
-def set_fee_parameters(lp_profit_fraction: uint256, admin_fee: uint256):
+def set_fee_parameters(reserved_profit_fraction: uint256, admin_fee: uint256):
     """
-    @notice Set LP/DAO-vs-rebalance split and DAO-vs-LP split parameters.
-    @param lp_profit_fraction The LP/DAO share of profits, with 10**10 precision.
-    @param admin_fee The DAO share of the LP/DAO bucket, with 10**10 precision.
+    @notice Set reserved-vs-rebalance split and DAO-vs-LP split parameters.
+    @param reserved_profit_fraction Gross profit share reserved from rebalancing, with 10**10 precision.
+    @param admin_fee The DAO share of the reserved profit bucket, with 10**10 precision.
     """
     self._check_admin()
-    self._set_fee_parameters(lp_profit_fraction, admin_fee)
+    self._set_fee_parameters(reserved_profit_fraction, admin_fee)
 
 
 @external

--- a/contracts/main/Twocrypto.vy
+++ b/contracts/main/Twocrypto.vy
@@ -1483,6 +1483,9 @@ def _claim_admin_fees():
         return
 
     admin_amounts: uint256[N_COINS] = self.admin_balances
+    if admin_amounts[0] == 0 and admin_amounts[1] == 0:
+        return
+
     for i: uint256 in range(N_COINS):
         if admin_amounts[i] > 0:
             self.admin_balances[i] = 0

--- a/contracts/main/Twocrypto.vy
+++ b/contracts/main/Twocrypto.vy
@@ -217,8 +217,6 @@ admin_balances: public(uint256[N_COINS])
 
 D: public(uint256)
 xcp_profit: public(uint256)
-xcp_profit_a: public(uint256)  # <--- Full profit at last claim of admin fees.
-admin_claimed_profit: public(uint256)  # Cumulative admin extraction from LP+DAO bucket, in vp units.
 
 virtual_price: public(uint256)  # <------ Cached (fast to read) virtual price.
 #                          The cached `virtual_price` is also used internally.
@@ -343,7 +341,6 @@ def __init__(
     self.cached_price_oracle = initial_price
     self.last_prices = initial_price
     self.last_timestamp = block.timestamp
-    self.xcp_profit_a = 10**18
 
     self.donation_duration = 7 * 86400
 
@@ -728,8 +725,6 @@ def add_liquidity(
         self.D = D
         self.virtual_price = 10**18
         self.xcp_profit = 10**18
-        self.xcp_profit_a = 10**18
-        self.admin_claimed_profit = 0
 
         self.mint(self, MINIMUM_LIQUIDITY)
         d_token -= MINIMUM_LIQUIDITY
@@ -1213,22 +1208,13 @@ def tweak_price(
     #
     # Mathematical basis for rebalancing condition:
     # 1. xcp_profit grows after virtual price, total growth since launch = (xcp_profit − 1)
-    # 2. We reserve lp_profit_fraction of the growth for LPs and admin, rest is used to rebalance the pool
+    # 2. We reserve lp_profit_fraction of the growth for LPs, rest is used to rebalance the pool.
 
     # Rebalancing condition basis:
-    #   virtual_price > 1 + (xcp_profit - 1) * lp_profit_fraction - admin_claimed_profit
-    #                  |         pre_admin_threshold_vp          |
-    # Interpretation:
-    #   1. xcp_profit - 1 is total gross profit growth above baseline.
-    #   2. Multiplying by lp_profit_fraction keeps only the LP+DAO retained share.
-    #   3. admin_claimed_profit subtracts what the admin has already extracted from that bucket.
-    #   4. The threshold is floored at PRECISION.
-    pre_admin_threshold_vp: uint256 = PRECISION + (
+    #   virtual_price > 1 + (xcp_profit - 1) * lp_profit_fraction
+
+    threshold_vp: uint256 = PRECISION + (
         unsafe_sub(max(xcp_profit, PRECISION), PRECISION) * self.lp_profit_fraction // FEE_PRECISION
-    )
-    threshold_vp: uint256 = max(
-        PRECISION,
-        pre_admin_threshold_vp - min(self.admin_claimed_profit, pre_admin_threshold_vp),
     )
     # user_supply < total_supply => vp_boosted > virtual_price
     # by not accounting for donation shares, virtual_price is boosted leading to rebalance trigger
@@ -1432,11 +1418,7 @@ def _update_policy_state(
 @internal
 def _claim_admin_fees():
     """
-    @notice Claims admin fees and sends it to fee_receiver set in the factory.
-    @dev Functionally similar to:
-         1. Calculating admin's share of fees,
-         2. minting LP tokens,
-         3. admin claims underlying tokens via remove_liquidity.
+    @notice Claims cached token-denominated admin fees to the factory receiver.
     """
 
     # --------------------- Check if fees can be claimed ---------------------
@@ -1444,84 +1426,33 @@ def _claim_admin_fees():
     # Disable fee claiming if:
     # 1. If time passed since last fee claim is less than
     #    MIN_ADMIN_FEE_CLAIM_INTERVAL.
-    # 2. Pool parameters are being ramped.
-    # 3. admin_fee is 0.
-    # 4. fee_receiver is not set.
+    # 2. fee_receiver is not set.
 
     last_claim_time: uint256 = self.last_admin_fee_claim_timestamp
     fee_receiver: address = staticcall factory.fee_receiver()
-    admin_fee: uint256 = self.admin_fee
     if (
         unsafe_sub(block.timestamp, last_claim_time) < MIN_ADMIN_FEE_CLAIM_INTERVAL or
-        self._is_ramping() or
-        admin_fee == 0 or
         fee_receiver == empty(address)
     ):
         return
 
-    xcp_profit: uint256 = self.xcp_profit  # <---------- Current pool profits.
-    xcp_profit_a: uint256 = self.xcp_profit_a  # <- Profits at previous claim.
-    current_lp_token_supply: uint256 = self.totalSupply
-    # Do not claim admin fees if:
-    # 1. insufficient profits accrued since last claim, and
-    # 2. there are less than 10**18 (or 1 unit of) lp tokens, else it can lead
-    #    to manipulated virtual prices.
+    admin_amounts: uint256[N_COINS] = self.admin_balances
+    has_fees: bool = False
+    for i: uint256 in range(N_COINS):
+        if admin_amounts[i] > 0:
+            has_fees = True
+            self.admin_balances[i] = 0
 
-    if xcp_profit <= xcp_profit_a or current_lp_token_supply < 10**18:
-        return
-
-    # ---------- Conditions met to claim admin fees: compute state. ----------
-    current_vprice: uint256 = self.virtual_price
-    balances: uint256[N_COINS] = self.balances
-    lp_profit_fraction: uint256 = self.lp_profit_fraction
-
-    #  Admin fees are calculated as follows.
-    #      1. Calculate accrued profit since last claim. `xcp_profit`
-    #         is the current profits. `xcp_profit_a` is the profits
-    #         at the previous claim.
-    #      2. Take out lp_profit_fraction, with 10**10 precision.
-    #      3. Take out admin's share, stored in self.admin_fee (also 10**10 precision).
-
-    fees: uint256 = unsafe_div(
-        unsafe_sub(xcp_profit, xcp_profit_a) * lp_profit_fraction * self.admin_fee,
-        FEE_PRECISION * FEE_PRECISION
-    )
-
-    if fees > 0:
-        # ---------------- Recalculate virtual price and admin claim offset -------
-        # We withdraw token balances without touching LP shares, so virtual price goes down.
-        updated_vprice: uint256 = current_vprice - fees
-        # Do not claim fees if doing so causes virtual price to drop below 10**18.
-        if updated_vprice < 10**18:
-            return
-        # Keep xcp_profit as the gross profit signal and track claimed admin
-        # extraction separately in the same virtual-price units as `fees`.
-        # Rebalancing thresholding then compares virtual_price against:
-        #   1 + (xcp_profit - 1) * lpf - admin_claimed_profit
-        self.admin_claimed_profit += fees
-
-        # ---------------------------- Update State ------------------------------
-        self.virtual_price = updated_vprice
-        self.last_admin_fee_claim_timestamp = block.timestamp
-        self.xcp_profit_a = xcp_profit  # <-------- Cache last claimed gross profit.
-
-        # Adjust D after admin removes liquidity
-        # no _get_D() because we can't claim during ramping
-        D: uint256 = self.D
-        # Decrease D proportional to fees/virtual_price
-        self.D = D - unsafe_div(D * fees, current_vprice)
-
-        # --------------------------- Handle Transfers ---------------------------
-
-        admin_amounts: uint256[N_COINS] = empty(uint256[N_COINS])
-        for i: uint256 in range(N_COINS):
-            admin_amounts[i] = (
-                balances[i] * fees // current_vprice
+            # Admin balances are already excluded from pool accounting, so
+            # claiming transfers tokens without touching self.balances or D.
+            assert extcall IERC20(coins[i]).transfer(
+                fee_receiver,
+                admin_amounts[i],
+                default_return_value=True
             )
-            # _transfer_out tokens to admin and update self.balances. State
-            # update to self.balances occurs before external contract calls:
-            self._transfer_out(i, admin_amounts[i], fee_receiver)
 
+    if has_fees:
+        self.last_admin_fee_claim_timestamp = block.timestamp
         log ClaimAdminFee(admin=fee_receiver, tokens=admin_amounts)
 
 

--- a/contracts/main/Twocrypto.vy
+++ b/contracts/main/Twocrypto.vy
@@ -2365,7 +2365,9 @@ def set_donation_parameters(
     assert protection_period > 0  # dev: "donation protection period cannot be zero"
     assert protection_period < 30 * 86_400  # dev: "donation protection period above maximum"
     assert protection_lp_threshold > 0  # dev: "donation protection threshold cannot be zero"
+    assert protection_lp_threshold <= PRECISION  # dev: "donation protection threshold above 1e18"
     assert max_shares_ratio > 0  # dev: "donation shares max ratio cannot be zero"
+    assert max_shares_ratio <= PRECISION  # dev: "donation shares max ratio above 1e18"
 
     self.donation_duration = duration
     self.donation_protection_period = protection_period

--- a/contracts/main/Twocrypto.vy
+++ b/contracts/main/Twocrypto.vy
@@ -643,13 +643,13 @@ def add_liquidity(
             # Convert the admin's share of the LP haircut into a pro-rata
             # token balance using the no-fee supply basis.
             fee_supply: uint256 = token_supply + d_token + d_token_fee
-            balances = self._book_admin_d_token_fee(
+            local_balances: uint256[N_COINS] = self._apply_admin_d_token_fee(
                 balances,
                 d_token_fee,
                 fee_supply,
             )
             if d_token_fee > 0 and self.reserved_profit_fraction > 0 and self.admin_fee > 0:
-                xp = self._xp(balances, price_scale)
+                xp = self._xp(local_balances, price_scale)
                 D = staticcall MATH.newton_D(A_gamma[0], A_gamma[1], xp, 0)
 
         if donation:
@@ -909,17 +909,17 @@ def _remove_liquidity_fixed_out(
     # the effective D burned. Convert the admin's share of that retained
     # LP fee into a balanced slice of post-withdraw token balances.
     fee_supply: uint256 = self.totalSupply - token_amount + d_token_fee
-    balances: uint256[N_COINS] = self.balances
-    balances[i] -= amount_i
-    balances[j] -= dy
+    local_balances: uint256[N_COINS] = self.balances
+    local_balances[i] -= amount_i
+    local_balances[j] -= dy
 
-    balances = self._book_admin_d_token_fee(
-        balances,
+    local_balances = self._apply_admin_d_token_fee(
+        local_balances,
         d_token_fee,
         fee_supply,
     )
     if d_token_fee > 0 and self.reserved_profit_fraction > 0 and self.admin_fee > 0:
-        xp = self._xp(balances, price_scale_preop)
+        xp = self._xp(local_balances, price_scale_preop)
         D = staticcall MATH.newton_D(A_gamma[0], A_gamma[1], xp, 0)
 
     # ---------------------------- State Updates -----------------------------
@@ -1405,8 +1405,8 @@ def tweak_price(
 
 
 @internal
-def _book_admin_d_token_fee(
-    balances: uint256[N_COINS],
+def _apply_admin_d_token_fee(
+    local_balances: uint256[N_COINS],
     d_token_fee: uint256,
     fee_supply: uint256,
 ) -> uint256[N_COINS]:
@@ -1417,11 +1417,11 @@ def _book_admin_d_token_fee(
     if admin_d_token_fee > 0:
         admin_amount: uint256 = 0
         for i: uint256 in range(N_COINS):
-            admin_amount = unsafe_div(balances[i] * admin_d_token_fee, fee_supply)
+            admin_amount = unsafe_div(local_balances[i] * admin_d_token_fee, fee_supply)
             self.admin_balances[i] += admin_amount
             self.balances[i] -= admin_amount
-            balances[i] -= admin_amount
-    return balances
+            local_balances[i] -= admin_amount
+    return local_balances
 
 
 @internal

--- a/contracts/main/Twocrypto.vy
+++ b/contracts/main/Twocrypto.vy
@@ -914,6 +914,32 @@ def _remove_liquidity_fixed_out(
     D_preop: uint256 = self._get_D(A_gamma, self._xp(self.balances, price_scale_preop))
     vp_preop: uint256 = 10**18 * self._xcp(D_preop, price_scale_preop) // self.totalSupply
 
+    j: uint256 = 1 - i
+    d_token_fee: uint256 = approx_fee * token_amount // FEE_PRECISION + 1
+    admin_d_token_fee: uint256 = unsafe_div(
+        d_token_fee * self.lp_profit_fraction * self.admin_fee,
+        FEE_PRECISION * FEE_PRECISION
+    )
+    if admin_d_token_fee > 0:
+        # Fixed-out withdrawal fees are charged in LP-token units by reducing
+        # the effective D burned. Convert the admin's share of that retained
+        # LP fee into a balanced slice of post-withdraw token balances.
+        fee_supply: uint256 = self.totalSupply - token_amount + d_token_fee
+        balances: uint256[N_COINS] = self.balances
+        balances[i] -= amount_i
+        balances[j] -= dy
+
+        admin_amount: uint256 = 0
+        for k: uint256 in range(N_COINS):
+            admin_amount = unsafe_div(balances[k] * admin_d_token_fee, fee_supply)
+            if admin_amount > 0:
+                self.admin_balances[k] += admin_amount
+                self.balances[k] -= admin_amount
+                balances[k] -= admin_amount
+
+        xp = self._xp(balances, price_scale_preop)
+        D = staticcall MATH.newton_D(A_gamma[0], A_gamma[1], xp, 0)
+
     # ---------------------------- State Updates -----------------------------
 
     self.burnFrom(msg.sender, token_amount)
@@ -923,8 +949,6 @@ def _remove_liquidity_fixed_out(
     if amount_i != 0:
         # one-sided withdrawals call with amount_i = 0, save extcall here
         self._transfer_out(i, amount_i, receiver)
-
-    j: uint256 = 1 - i
 
     self._transfer_out(j, dy, receiver)
 
@@ -938,7 +962,7 @@ def _remove_liquidity_fixed_out(
             token_amount=token_amount,
             coin_index=j,
             coin_amount=dy,
-            approx_fee=approx_fee * token_amount // FEE_PRECISION + 1, # LP units, not coins!
+            approx_fee=d_token_fee, # LP units, not coins!
             packed_price_scale=price_scale
         )
     else:
@@ -946,7 +970,7 @@ def _remove_liquidity_fixed_out(
             provider=msg.sender,
             lp_token_amount=token_amount,
             token_amounts=token_amounts,
-            approx_fee=approx_fee * token_amount // FEE_PRECISION + 1, # LP units
+            approx_fee=d_token_fee, # LP units
             price_scale=price_scale
         )
 

--- a/contracts/main/Twocrypto.vy
+++ b/contracts/main/Twocrypto.vy
@@ -796,17 +796,18 @@ def remove_liquidity(
         # before external calls:
         self._transfer_out(i, withdraw_amounts[i], receiver)
 
-    price_scale: uint256 = self.cached_price_scale
-    self._update_policy_state(
-        self._xp(self.balances, price_scale),
-        price_scale,
-        self.cached_price_oracle,
-        self.last_prices,
-        self.virtual_price,
-        self.xcp_profit,
-        self.D,
-        False,
-    )
+    if withdraw_amounts[0] > 0 or withdraw_amounts[1] > 0:
+        price_scale: uint256 = self.cached_price_scale
+        self._update_policy_state(
+            self._xp(self.balances, price_scale),
+            price_scale,
+            self.cached_price_oracle,
+            self.last_prices,
+            self.virtual_price,
+            self.xcp_profit,
+            self.D,
+            False,
+        )
 
     # We intentionally use the unadjusted `amount` here as the amount of lp
     # tokens burnt is `amount`, regardless of the rounding error.

--- a/contracts/main/Twocrypto.vy
+++ b/contracts/main/Twocrypto.vy
@@ -213,6 +213,8 @@ donation_protection_lp_threshold: public(uint256)
 donation_protection_extension_remainder: uint256
 
 balances: public(uint256[N_COINS])
+admin_balances: public(uint256[N_COINS])
+
 D: public(uint256)
 xcp_profit: public(uint256)
 xcp_profit_a: public(uint256)  # <--- Full profit at last claim of admin fees.
@@ -388,7 +390,7 @@ def _transfer_in(
         # accounts for coin balances of the contract) is atleast dx.
         # If we checked for received_amounts == dx, an extra transfer without a
         # call to exchange_received will break the method.
-        dx: uint256 = coin_balance - self.balances[_coin_idx]
+        dx: uint256 = coin_balance - self.balances[_coin_idx] - self.admin_balances[_coin_idx]
         assert dx >= _dx, "!coins"
 
         # Adjust balances
@@ -638,6 +640,26 @@ def add_liquidity(
             self._calc_token_fee(amounts_received, xp, donation, True) * d_token // FEE_PRECISION + 1
         ) # for donations - we only take NOISE_FEE (check _calc_token_fee)
         d_token -= d_token_fee
+
+        if not donation:
+            admin_d_token_fee: uint256 = unsafe_div(
+                d_token_fee * self.lp_profit_fraction * self.admin_fee,
+                FEE_PRECISION * FEE_PRECISION
+            )
+            if admin_d_token_fee > 0:
+                # Convert the admin's share of the LP haircut into a pro-rata
+                # token balance using the no-fee supply basis.
+                fee_supply: uint256 = token_supply + d_token + d_token_fee
+                admin_amount: uint256 = 0
+                for i: uint256 in range(N_COINS):
+                    admin_amount = unsafe_div(balances[i] * admin_d_token_fee, fee_supply)
+                    if admin_amount > 0:
+                        self.admin_balances[i] += admin_amount
+                        self.balances[i] -= admin_amount
+                        balances[i] -= admin_amount
+
+                xp = self._xp(balances, price_scale)
+                D = staticcall MATH.newton_D(A_gamma[0], A_gamma[1], xp, 0)
 
         if donation:
             assert receiver == empty(address), "nonzero receiver"

--- a/contracts/main/Twocrypto.vy
+++ b/contracts/main/Twocrypto.vy
@@ -640,20 +640,15 @@ def add_liquidity(
         d_token -= d_token_fee
 
         if not donation:
-            admin_d_token_fee: uint256 = unsafe_div(
-                d_token_fee * self.reserved_profit_fraction * self.admin_fee,
-                FEE_PRECISION * FEE_PRECISION
+            # Convert the admin's share of the LP haircut into a pro-rata
+            # token balance using the no-fee supply basis.
+            fee_supply: uint256 = token_supply + d_token + d_token_fee
+            balances = self._book_admin_d_token_fee(
+                balances,
+                d_token_fee,
+                fee_supply,
             )
-            if admin_d_token_fee > 0:
-                # Convert the admin's share of the LP haircut into a pro-rata
-                # token balance using the no-fee supply basis.
-                fee_supply: uint256 = token_supply + d_token + d_token_fee
-                balances = self._book_admin_token_fee(
-                    balances,
-                    admin_d_token_fee,
-                    fee_supply,
-                )
-
+            if d_token_fee > 0 and self.reserved_profit_fraction > 0 and self.admin_fee > 0:
                 xp = self._xp(balances, price_scale)
                 D = staticcall MATH.newton_D(A_gamma[0], A_gamma[1], xp, 0)
 
@@ -910,25 +905,20 @@ def _remove_liquidity_fixed_out(
 
     j: uint256 = 1 - i
     d_token_fee: uint256 = approx_fee * token_amount // FEE_PRECISION + 1
-    admin_d_token_fee: uint256 = unsafe_div(
-        d_token_fee * self.reserved_profit_fraction * self.admin_fee,
-        FEE_PRECISION * FEE_PRECISION
+    # Fixed-out withdrawal fees are charged in LP-token units by reducing
+    # the effective D burned. Convert the admin's share of that retained
+    # LP fee into a balanced slice of post-withdraw token balances.
+    fee_supply: uint256 = self.totalSupply - token_amount + d_token_fee
+    balances: uint256[N_COINS] = self.balances
+    balances[i] -= amount_i
+    balances[j] -= dy
+
+    balances = self._book_admin_d_token_fee(
+        balances,
+        d_token_fee,
+        fee_supply,
     )
-    if admin_d_token_fee > 0:
-        # Fixed-out withdrawal fees are charged in LP-token units by reducing
-        # the effective D burned. Convert the admin's share of that retained
-        # LP fee into a balanced slice of post-withdraw token balances.
-        fee_supply: uint256 = self.totalSupply - token_amount + d_token_fee
-        balances: uint256[N_COINS] = self.balances
-        balances[i] -= amount_i
-        balances[j] -= dy
-
-        balances = self._book_admin_token_fee(
-            balances,
-            admin_d_token_fee,
-            fee_supply,
-        )
-
+    if d_token_fee > 0 and self.reserved_profit_fraction > 0 and self.admin_fee > 0:
         xp = self._xp(balances, price_scale_preop)
         D = staticcall MATH.newton_D(A_gamma[0], A_gamma[1], xp, 0)
 
@@ -1415,17 +1405,22 @@ def tweak_price(
 
 
 @internal
-def _book_admin_token_fee(
+def _book_admin_d_token_fee(
     balances: uint256[N_COINS],
-    admin_d_token_fee: uint256,
+    d_token_fee: uint256,
     fee_supply: uint256,
 ) -> uint256[N_COINS]:
-    admin_amount: uint256 = 0
-    for i: uint256 in range(N_COINS):
-        admin_amount = unsafe_div(balances[i] * admin_d_token_fee, fee_supply)
-        self.admin_balances[i] += admin_amount
-        self.balances[i] -= admin_amount
-        balances[i] -= admin_amount
+    admin_d_token_fee: uint256 = unsafe_div(
+        d_token_fee * self.reserved_profit_fraction * self.admin_fee,
+        FEE_PRECISION * FEE_PRECISION
+    )
+    if admin_d_token_fee > 0:
+        admin_amount: uint256 = 0
+        for i: uint256 in range(N_COINS):
+            admin_amount = unsafe_div(balances[i] * admin_d_token_fee, fee_supply)
+            self.admin_balances[i] += admin_amount
+            self.balances[i] -= admin_amount
+            balances[i] -= admin_amount
     return balances
 
 

--- a/contracts/main/Twocrypto.vy
+++ b/contracts/main/Twocrypto.vy
@@ -1051,6 +1051,15 @@ def _exchange(
     assert dy >= min_dy, "slippage"
     y -= dy
 
+    admin_fee_amount: uint256 = unsafe_div(
+        fee * self.lp_profit_fraction * self.admin_fee,
+        FEE_PRECISION * FEE_PRECISION
+    )
+    if admin_fee_amount > 0:
+        self.admin_balances[j] += admin_fee_amount
+        self.balances[j] -= admin_fee_amount
+        y -= admin_fee_amount
+
     y *= PRECISIONS[j]
     if j > 0:
         y = unsafe_div(y * price_scale, PRECISION)

--- a/contracts/main/Twocrypto.vy
+++ b/contracts/main/Twocrypto.vy
@@ -1,5 +1,5 @@
 # pragma version 0.4.3
-# pragma optimize gas
+# pragma optimize codesize
 """
 @title Twocrypto
 @author Curve.Fi
@@ -647,13 +647,11 @@ def add_liquidity(
                 # Convert the admin's share of the LP haircut into a pro-rata
                 # token balance using the no-fee supply basis.
                 fee_supply: uint256 = token_supply + d_token + d_token_fee
-                admin_amount: uint256 = 0
-                for i: uint256 in range(N_COINS):
-                    admin_amount = unsafe_div(balances[i] * admin_d_token_fee, fee_supply)
-                    if admin_amount > 0:
-                        self.admin_balances[i] += admin_amount
-                        self.balances[i] -= admin_amount
-                        balances[i] -= admin_amount
+                balances = self._book_admin_token_fee(
+                    balances,
+                    admin_d_token_fee,
+                    fee_supply,
+                )
 
                 xp = self._xp(balances, price_scale)
                 D = staticcall MATH.newton_D(A_gamma[0], A_gamma[1], xp, 0)
@@ -924,13 +922,11 @@ def _remove_liquidity_fixed_out(
         balances[i] -= amount_i
         balances[j] -= dy
 
-        admin_amount: uint256 = 0
-        for k: uint256 in range(N_COINS):
-            admin_amount = unsafe_div(balances[k] * admin_d_token_fee, fee_supply)
-            if admin_amount > 0:
-                self.admin_balances[k] += admin_amount
-                self.balances[k] -= admin_amount
-                balances[k] -= admin_amount
+        balances = self._book_admin_token_fee(
+            balances,
+            admin_d_token_fee,
+            fee_supply,
+        )
 
         xp = self._xp(balances, price_scale_preop)
         D = staticcall MATH.newton_D(A_gamma[0], A_gamma[1], xp, 0)
@@ -1379,6 +1375,21 @@ def tweak_price(
 
 
 @internal
+def _book_admin_token_fee(
+    balances: uint256[N_COINS],
+    admin_d_token_fee: uint256,
+    fee_supply: uint256,
+) -> uint256[N_COINS]:
+    admin_amount: uint256 = 0
+    for i: uint256 in range(N_COINS):
+        admin_amount = unsafe_div(balances[i] * admin_d_token_fee, fee_supply)
+        self.admin_balances[i] += admin_amount
+        self.balances[i] -= admin_amount
+        balances[i] -= admin_amount
+    return balances
+
+
+@internal
 def _update_policy_state(
     xp: uint256[N_COINS],
     price_scale: uint256,
@@ -1437,10 +1448,8 @@ def _claim_admin_fees():
         return
 
     admin_amounts: uint256[N_COINS] = self.admin_balances
-    has_fees: bool = False
     for i: uint256 in range(N_COINS):
         if admin_amounts[i] > 0:
-            has_fees = True
             self.admin_balances[i] = 0
 
             # Admin balances are already excluded from pool accounting, so
@@ -1451,9 +1460,8 @@ def _claim_admin_fees():
                 default_return_value=True
             )
 
-    if has_fees:
-        self.last_admin_fee_claim_timestamp = block.timestamp
-        log ClaimAdminFee(admin=fee_receiver, tokens=admin_amounts)
+    self.last_admin_fee_claim_timestamp = block.timestamp
+    log ClaimAdminFee(admin=fee_receiver, tokens=admin_amounts)
 
 
 @internal
@@ -2373,7 +2381,6 @@ def _set_allowlist(add: DynArray[address, 16], remove: DynArray[address, 16]):
         self.lp_allowlist[empty(address)] = True
 
     log LPAllowlistChanged(user=empty(address), allowed=self.lp_allowlist[empty(address)])
-
 
 
 @external

--- a/contracts/main/TwocryptoView.vy
+++ b/contracts/main/TwocryptoView.vy
@@ -148,6 +148,9 @@ def calc_token_amount(
 
     d_token, amountsp, xp = self._calc_dtoken_nofee(amounts, deposit, swap)
     if deposit and staticcall Curve(swap).D() == 0:
+        # Donation adds are rejected by the pool until regular liquidity exists.
+        if donation:
+            return 0
         if d_token <= MINIMUM_LIQUIDITY:
             return 0
         return d_token - MINIMUM_LIQUIDITY

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -14,7 +14,7 @@ from tests.utils.constants import (
 from tests.utils.embedded_periphery import load_twocrypto_with_embedded_periphery
 from tests.utils.god_mode import GodModePool
 
-# boa.env.evm.patch.code_size_limit = 56_000
+boa.env.evm.patch.code_size_limit = 56_000
 
 # Constants
 INITIAL_PRICES = [10**18, 1500 * 10**18]  # price relative to coin_id = 0

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -14,7 +14,7 @@ from tests.utils.constants import (
 from tests.utils.embedded_periphery import load_twocrypto_with_embedded_periphery
 from tests.utils.god_mode import GodModePool
 
-boa.env.evm.patch.code_size_limit = 56_000
+# boa.env.evm.patch.code_size_limit = 56_000
 
 # Constants
 INITIAL_PRICES = [10**18, 1500 * 10**18]  # price relative to coin_id = 0

--- a/tests/fuzzing/test_admin_fee.py
+++ b/tests/fuzzing/test_admin_fee.py
@@ -2,9 +2,13 @@ import boa
 from hypothesis import given, settings
 from hypothesis import strategies as st
 from pytest import fixture
-from tests.conftest import INITIAL_PRICES
+from tests.conftest import INITIAL_PRICES, _crypto_swap_with_deposit, _deploy_pool
+from tests.utils.constants import POOL_DEPLOYER
 
 SETTINGS = {"max_examples": 100, "deadline": None}
+ADMIN_CLAIM_SETTINGS = {"max_examples": 25, "deadline": None}
+FEE_PRECISION = 10**10
+EXCHANGE_FEE = 10**7
 
 
 @fixture(scope="module")
@@ -12,6 +16,26 @@ def user_b():
     acc = boa.env.generate_address()
     boa.env.set_balance(acc, 10**25)
     return acc
+
+
+@fixture(scope="module")
+def admin_fee_trader(coins, pool):
+    acc = boa.env.generate_address()
+    boa.env.set_balance(acc, 10**25)
+    for coin in coins:
+        coin.approve(pool, 2**256 - 1, sender=acc)
+    return acc
+
+
+@fixture(scope="module")
+def concentrated_pool_with_deposit(factory, coins, params, deployer, user):
+    high_a_params = params.copy()
+    high_a_params["A"] = 10_000 * 10_000
+    high_a_params["mid_fee"] = EXCHANGE_FEE
+    high_a_params["out_fee"] = EXCHANGE_FEE
+
+    pool = POOL_DEPLOYER.at(_deploy_pool(factory, high_a_params, coins, deployer))
+    return _crypto_swap_with_deposit(coins, user, pool, INITIAL_PRICES)
 
 
 @given(ratio=st.floats(min_value=0.0001, max_value=0.1))
@@ -46,3 +70,145 @@ def test_admin_fee_after_deposit(pool, coins, fee_receiver, user, user_b, ratio)
     assert coins[0].balanceOf(fee_receiver) + coins[1].balanceOf(fee_receiver) == 0
 
     return pool
+
+
+@given(
+    lp_profit_fraction=st.one_of(
+        st.just(0),
+        st.integers(min_value=10**8, max_value=FEE_PRECISION),
+    ),
+    admin_fee=st.one_of(
+        st.just(0),
+        st.integers(min_value=10**8, max_value=FEE_PRECISION),
+    ),
+    swap_coin=st.integers(min_value=0, max_value=1),
+    add_imbalance=st.integers(min_value=1, max_value=20),
+    withdraw_coin=st.integers(min_value=0, max_value=1),
+    withdraw_fraction=st.integers(min_value=1, max_value=20),
+)
+@settings(**ADMIN_CLAIM_SETTINGS)
+def test_exchange_admin_fee_share_tracks_washtrade_volume(
+    concentrated_pool_with_deposit,
+    coins,
+    fee_receiver,
+    factory_admin,
+    admin_fee_trader,
+    lp_profit_fraction,
+    admin_fee,
+    swap_coin,
+    add_imbalance,
+    withdraw_coin,
+    withdraw_fraction,
+):
+    pool = concentrated_pool_with_deposit
+    initial_price_scale = pool.price_scale()
+
+    pool.set_fee_parameters(0, 0, sender=factory_admin)
+    for coin in coins:
+        coin.approve(pool, 2**256 - 1, sender=admin_fee_trader)
+
+    trader_lp = pool.balanceOf(admin_fee_trader)
+    if trader_lp == 0:
+        amounts = [
+            10_000 * 10**18,
+            10_000 * 10**18 * 10**18 // initial_price_scale,
+        ]
+        for i, amount in enumerate(amounts):
+            boa.deal(coins[i], admin_fee_trader, amount)
+        pool.add_liquidity(amounts, 0, admin_fee_trader, sender=admin_fee_trader)
+        trader_lp = pool.balanceOf(admin_fee_trader)
+
+    pool.set_fee_parameters(lp_profit_fraction, admin_fee, sender=factory_admin)
+    receiver_before = [coin.balanceOf(fee_receiver) for coin in coins]
+
+    # Fixed-out withdrawal calls the autoclaim path before taking its own fee.
+    # Do it first so later assertions only need to reason about newly cached fees.
+    token_amount = max(trader_lp // 10, 1)
+    amount_i = pool.balances(withdraw_coin) // (10_000 + withdraw_fraction)
+    pool.remove_liquidity_fixed_out(
+        token_amount,
+        withdraw_coin,
+        amount_i,
+        0,
+        admin_fee_trader,
+        sender=admin_fee_trader,
+    )
+    remove_admin_value = (
+        pool.admin_balances(0) + pool.admin_balances(1) * initial_price_scale // 10**18
+    )
+
+    traded_value = 0
+    for k in range(20):
+        i = (swap_coin + k) % 2
+        j = 1 - i
+        swap_amount = pool.balances(i) // 10_000
+        traded_value += swap_amount if i == 0 else swap_amount * initial_price_scale // 10**18
+        boa.deal(coins[i], admin_fee_trader, swap_amount)
+        pool.exchange(i, j, swap_amount, 0, admin_fee_trader, sender=admin_fee_trader)
+
+    exchange_admin = [
+        pool.admin_balances(0),
+        pool.admin_balances(1),
+    ]
+    exchange_admin_value = (
+        exchange_admin[0] + exchange_admin[1] * initial_price_scale // 10**18 - remove_admin_value
+    )
+    expected_exchange_admin_value = (
+        traded_value
+        * EXCHANGE_FEE
+        * lp_profit_fraction
+        * admin_fee
+        // FEE_PRECISION
+        // FEE_PRECISION
+        // FEE_PRECISION
+    )
+
+    # Generate add-liquidity haircut fees using a small controlled imbalance.
+    add_amounts = [
+        pool.balances(0) // 20_000,
+        pool.balances(1) // (20_000 + add_imbalance),
+    ]
+    for i, amount in enumerate(add_amounts):
+        boa.deal(coins[i], admin_fee_trader, amount)
+    pool.add_liquidity(add_amounts, 0, admin_fee_trader, sender=admin_fee_trader)
+
+    assert pool.price_scale() == initial_price_scale
+
+    expected_admin = [pool.admin_balances(i) for i in range(2)]
+    expected_admin_value = expected_admin[0] + expected_admin[1] * initial_price_scale // 10**18
+    physical_before_claim = [coin.balanceOf(pool) for coin in coins]
+    total_supply_before_claim = pool.totalSupply()
+    virtual_price_before_claim = pool.virtual_price()
+    xcp_profit_before_claim = pool.xcp_profit()
+    D_before_claim = pool.D()
+
+    boa.env.time_travel(seconds=86_400)
+    pool.internal._claim_admin_fees()
+
+    receiver_after = [coin.balanceOf(fee_receiver) for coin in coins]
+    physical_after_claim = [coin.balanceOf(pool) for coin in coins]
+    owned_after = [pool.balances(i) for i in range(2)]
+    receiver_value_received = (
+        receiver_after[0]
+        - receiver_before[0]
+        + (receiver_after[1] - receiver_before[1]) * initial_price_scale // 10**18
+    )
+
+    if lp_profit_fraction == 0 or admin_fee == 0:
+        assert expected_admin == [0, 0]
+        assert exchange_admin_value == 0
+    else:
+        # The pool is highly concentrated, trades are small, and mid_fee == out_fee,
+        # so washtrade admin take should track fee * LP/DAO split * DAO split.
+        assert abs(exchange_admin_value - expected_exchange_admin_value) <= max(
+            expected_exchange_admin_value // 100, 10**12
+        )
+        assert expected_admin_value > 0
+    assert receiver_value_received == expected_admin_value
+    assert [pool.admin_balances(i) for i in range(2)] == [0, 0]
+    assert owned_after == [physical_after_claim[i] for i in range(2)]
+    assert [physical_before_claim[i] - physical_after_claim[i] for i in range(2)] == expected_admin
+    assert pool.totalSupply() == total_supply_before_claim
+    assert pool.virtual_price() == virtual_price_before_claim
+    assert pool.xcp_profit() == xcp_profit_before_claim
+    assert pool.D() == D_before_claim

--- a/tests/fuzzing/test_admin_fee.py
+++ b/tests/fuzzing/test_admin_fee.py
@@ -73,7 +73,7 @@ def test_admin_fee_after_deposit(pool, coins, fee_receiver, user, user_b, ratio)
 
 
 @given(
-    lp_profit_fraction=st.one_of(
+    reserved_profit_fraction=st.one_of(
         st.just(0),
         st.integers(min_value=10**8, max_value=FEE_PRECISION),
     ),
@@ -93,7 +93,7 @@ def test_exchange_admin_fee_share_tracks_washtrade_volume(
     fee_receiver,
     factory_admin,
     admin_fee_trader,
-    lp_profit_fraction,
+    reserved_profit_fraction,
     admin_fee,
     swap_coin,
     add_imbalance,
@@ -118,7 +118,7 @@ def test_exchange_admin_fee_share_tracks_washtrade_volume(
         pool.add_liquidity(amounts, 0, admin_fee_trader, sender=admin_fee_trader)
         trader_lp = pool.balanceOf(admin_fee_trader)
 
-    pool.set_fee_parameters(lp_profit_fraction, admin_fee, sender=factory_admin)
+    pool.set_fee_parameters(reserved_profit_fraction, admin_fee, sender=factory_admin)
     receiver_before = [coin.balanceOf(fee_receiver) for coin in coins]
 
     # Fixed-out withdrawal calls the autoclaim path before taking its own fee.
@@ -156,7 +156,7 @@ def test_exchange_admin_fee_share_tracks_washtrade_volume(
     expected_exchange_admin_value = (
         traded_value
         * EXCHANGE_FEE
-        * lp_profit_fraction
+        * reserved_profit_fraction
         * admin_fee
         // FEE_PRECISION
         // FEE_PRECISION
@@ -194,7 +194,7 @@ def test_exchange_admin_fee_share_tracks_washtrade_volume(
         + (receiver_after[1] - receiver_before[1]) * initial_price_scale // 10**18
     )
 
-    if lp_profit_fraction == 0 or admin_fee == 0:
+    if reserved_profit_fraction == 0 or admin_fee == 0:
         assert expected_admin == [0, 0]
         assert exchange_admin_value == 0
     else:

--- a/tests/fuzzing/test_exchange_fuzzing.py
+++ b/tests/fuzzing/test_exchange_fuzzing.py
@@ -36,6 +36,7 @@ def test_exchange_all(
     measured_j = coins[j].balanceOf(user)
     d_balance_i = pool_with_deposit.balances(i)
     d_balance_j = pool_with_deposit.balances(j)
+    d_admin_j = pool_with_deposit.admin_balances(j)
 
     with boa.env.prank(user):
         pool_with_deposit.exchange(i, j, amount, int(0.999 * calculated))
@@ -44,12 +45,13 @@ def test_exchange_all(
     measured_j = coins[j].balanceOf(user) - measured_j
     d_balance_i = pool_with_deposit.balances(i) - d_balance_i
     d_balance_j = pool_with_deposit.balances(j) - d_balance_j
+    d_admin_j = pool_with_deposit.admin_balances(j) - d_admin_j
 
     assert amount == measured_i
     assert calculated == measured_j
 
     assert d_balance_i == amount
-    assert -d_balance_j == measured_j
+    assert -d_balance_j == measured_j + d_admin_j
 
 
 @given(
@@ -81,6 +83,7 @@ def test_exchange_received_success(
     measured_j = coins[j].balanceOf(user)
     d_balance_i = pool_with_deposit.balances(i)
     d_balance_j = pool_with_deposit.balances(j)
+    d_admin_j = pool_with_deposit.admin_balances(j)
 
     with boa.env.prank(user):
         coins[i].transfer(pool_with_deposit, amount)
@@ -90,12 +93,14 @@ def test_exchange_received_success(
     measured_j = coins[j].balanceOf(user) - measured_j
     d_balance_i = pool_with_deposit.balances(i) - d_balance_i
     d_balance_j = pool_with_deposit.balances(j) - d_balance_j
+    d_admin_j = pool_with_deposit.admin_balances(j) - d_admin_j
 
     assert amount == measured_i
     assert calculated == measured_j == out
 
     assert d_balance_i == amount
-    assert -d_balance_j == measured_j == out
+    assert -d_balance_j == measured_j + d_admin_j
+    assert measured_j == out
 
 
 @given(

--- a/tests/stateful/stateful_base.py
+++ b/tests/stateful/stateful_base.py
@@ -24,7 +24,6 @@ class StatefulBase(RuleBasedStateMachine):
     balances = None
     decimals = None
     xcp_profit = 0
-    xcp_profit_a = 0
     depositors = None
     equilibrium = 0
     swapped_once = False
@@ -78,7 +77,6 @@ class StatefulBase(RuleBasedStateMachine):
 
         # initial profit is 1e18
         self.xcp_profit = 1e18
-        self.xcp_profit_a = 1e18
 
         self.depositors = set()
 
@@ -246,7 +244,6 @@ class StatefulBase(RuleBasedStateMachine):
         # update the profit since it increases through `tweak_price`
         # which is called by `add_liquidity`
         self.xcp_profit = self.pool.xcp_profit()
-        self.xcp_profit_a = self.pool.xcp_profit_a()
 
         if not donate:
             self.depositors.add(user)
@@ -459,35 +456,28 @@ class StatefulBase(RuleBasedStateMachine):
         if self.pool.balanceOf(user) <= 1e0:
             self.depositors.remove(user)
 
-        # invarinant upkeeping logic:
-        # imbalanced removals can trigger a claim of admin fees
+        # invariant upkeeping logic:
+        # imbalanced removals can trigger a claim of cached admin fees
+        if self.fee_receiver != boa.eval("empty(address)"):
+            admin_balances_post = [c.balanceOf(self.fee_receiver) for c in self.coins]
+            claimed_amounts = [admin_balances_post[i] - admin_balances_pre[i] for i in range(2)]
+        else:
+            claimed_amounts = [0, 0]
 
-        # store the balances of the fee receiver after the removal
-        new_xcp_profit_a = self.pool.xcp_profit_a()
-        # store the balances of the fee receiver before the removal
-        old_xcp_profit_a = self.xcp_profit_a
-        # check if the admin fees were claimed (not always the case)
-        if new_xcp_profit_a > old_xcp_profit_a and self.fee_receiver != boa.eval("empty(address)"):
+        if claimed_amounts[0] > 0 or claimed_amounts[1] > 0:
             event("admin fees claim was detected")
             note("claiming admin fees during removal")
-            # if the admin fees were claimed we have to update xcp
-            self.xcp_profit_a = new_xcp_profit_a
 
-            # store the balances of the fee receiver after the removal
-            # (should be higher than before the removal)
-            admin_balances_post = [c.balanceOf(self.fee_receiver) for c in self.coins]
             for i in range(2):
-                claimed_amount = admin_balances_post[i] - admin_balances_pre[i]
+                claimed_amount = claimed_amounts[i]
                 note("admin received {:.2e} of token {}".format(claimed_amount, i))
                 assert (
                     claimed_amount > 0
                     # decimals: with such a low precision admin fees might be 0
                     or self.decimals[i] <= 9
+                    # The claim path may have fees only in the other coin.
+                    or claimed_amounts[1 - i] > 0
                 ), f"the admin fees collected should be positive for coin {i}"
-                assert not self.is_ramping(), "claim admin fees while ramping"
-
-                # deduce the claimed amount from the pool balances
-                self.balances[i] -= claimed_amount
 
         # update test-tracked xcp profit
         self.xcp_profit = self.pool.xcp_profit()
@@ -557,13 +547,14 @@ class StatefulBase(RuleBasedStateMachine):
     @invariant()
     def balances(self):  # noqa: F811
         balances = [self.pool.balances(i) for i in range(2)]
+        admin_balances = [self.pool.admin_balances(i) for i in range(2)]
         balance_of = [c.balanceOf(self.pool) for c in self.coins]
         for i in range(2):
             assert (
                 self.balances[i] == balances[i]
             ), "test-tracked balances don't match pool-tracked balances"
             assert (
-                self.balances[i] == balance_of[i]
+                self.balances[i] + admin_balances[i] == balance_of[i]
             ), "test-tracked balances don't match token-tracked balances"
 
     @invariant()
@@ -599,7 +590,6 @@ class StatefulBase(RuleBasedStateMachine):
 
         assert xcp_profit >= self.xcp_profit, "xcp_profit has decreased"
         self.xcp_profit = xcp_profit
-        self.xcp_profit_a = self.pool.xcp_profit_a()
 
 
 TestBase = StatefulBase.TestCase

--- a/tests/stateful/stateful_base.py
+++ b/tests/stateful/stateful_base.py
@@ -162,12 +162,12 @@ class StatefulBase(RuleBasedStateMachine):
         old_equilibrium = self.equilibrium
 
         # price of the first coin is always 1
-        xp = self.coins[0].balanceOf(self.pool) * (
+        xp = self.pool.balances(0) * (
             10 ** (18 - self.decimals[0])  # normalize to 18 decimals
         )
 
         yp = (
-            self.coins[1].balanceOf(self.pool)
+            self.pool.balances(1)
             * self.pool.price_scale()  # price of the second coin
             * (10 ** (18 - self.decimals[1]))  # normalize to 18 decimals
         )
@@ -238,8 +238,8 @@ class StatefulBase(RuleBasedStateMachine):
         if old_total_supply == 0:
             self.total_supply += MINIMUM_LIQUIDITY
 
-        # pool balances should increase by the amounts
-        self.balances = [x + y for x, y in zip(self.balances, amounts)]
+        # Admin fees are cached in token balances outside AMM accounting.
+        self.balances = [self.pool.balances(i) for i in range(2)]
 
         # update the profit since it increases through `tweak_price`
         # which is called by `add_liquidity`
@@ -334,9 +334,8 @@ class StatefulBase(RuleBasedStateMachine):
             delta_balance_j == expected_dy == actual_dy
         ), "didn't receive the right amount of token y"
 
-        # update the internal balances of the test for the invariants
-        self.balances[i] -= delta_balance_i
-        self.balances[j] -= delta_balance_j
+        # Admin fees are cached in token balances outside AMM accounting.
+        self.balances = [self.pool.balances(k) for k in range(2)]
 
         # update the profit made by the pool
         self.xcp_profit = self.pool.xcp_profit()
@@ -367,8 +366,7 @@ class StatefulBase(RuleBasedStateMachine):
         # total apply should have decreased by the amount of liquidity
         # withdrawn
         self.total_supply -= amount
-        # update the internal balances of the test for the invariants
-        self.balances = [b - a for a, b in zip(amounts, self.balances)]
+        self.balances = [self.pool.balances(i) for i in range(2)]
 
         # we don't want to keep track of users with low liquidity because
         # it would approximate to 0 tokens and break the invariants.
@@ -397,7 +395,7 @@ class StatefulBase(RuleBasedStateMachine):
         # store balances of the fee receiver before the removal
         admin_balances_pre = [c.balanceOf(self.fee_receiver) for c in self.coins]
         # store the balance of the user before the removal
-        user_balances_pre = self.coins[coin_idx].balanceOf(user)
+        # user_balances_pre = self.coins[coin_idx].balanceOf(user)
 
         # lp tokens before the removal
         lp_tokens_balance_pre = self.pool.balanceOf(user)
@@ -443,11 +441,10 @@ class StatefulBase(RuleBasedStateMachine):
         if lp_tokens_to_withdraw < 1e15:
             event("successful removal of liquidity with low amounts")
 
-        # compute the change in balances
-        user_balances_post = abs(user_balances_pre - self.coins[coin_idx].balanceOf(user))
+        # # compute the change in balances
+        # user_balances_post = abs(user_balances_pre - self.coins[coin_idx].balanceOf(user))
 
-        # update internal balances
-        self.balances[coin_idx] -= user_balances_post
+        self.balances = [self.pool.balances(i) for i in range(2)]
         # total supply should decrease by the amount of tokens withdrawn
         self.total_supply -= lp_tokens_to_withdraw
 
@@ -522,22 +519,22 @@ class StatefulBase(RuleBasedStateMachine):
             # remove all liquidity from all real depositors
             for d in self.depositors:
                 # store the current balances of the pool
-                prev_balances = [c.balanceOf(self.pool) for c in self.coins]
+                prev_balances = [self.pool.balances(i) for i in range(2)]
                 # withdraw all liquidity from the depositor
                 tokens = self.pool.balanceOf(d)
                 self.pool.remove_liquidity(tokens, [0] * 2, sender=d)
                 assert self.pool.balanceOf(d) == 0, "depositor still has LP after withdrawal"
                 # assert current balances are less as the previous ones
-                for c, b in zip(self.coins, prev_balances):
+                for i, b in enumerate(prev_balances):
                     # check that the balance of the pool is less than before
-                    if c.balanceOf(self.pool) == b:
+                    if self.pool.balances(i) == b:
                         assert self.pool.balanceOf(d) < 10, (
                             "balance of the depositor is not small enough to"
                             "justify a withdrawal that does not affect the"
                             "pool token balance"
                         )
                     else:
-                        assert c.balanceOf(self.pool) < b, (
+                        assert self.pool.balances(i) < b, (
                             "one withdrawal didn't reduce the liquidity" "of the pool"
                         )
 

--- a/tests/stateful/stateful_base.py
+++ b/tests/stateful/stateful_base.py
@@ -29,7 +29,7 @@ class StatefulBase(RuleBasedStateMachine):
     swapped_once = False
     fee_receiver = None
     admin = None
-    lp_profit_fraction = 0
+    reserved_profit_fraction = 0
     admin_fee = 0
 
     fee_split_presets = [
@@ -86,15 +86,15 @@ class StatefulBase(RuleBasedStateMachine):
 
         self.fee_receiver = FACTORY_DEPLOYER.at(pool.factory()).fee_receiver()
         self.admin = FACTORY_DEPLOYER.at(pool.factory()).admin()
-        self.lp_profit_fraction, self.admin_fee = fee_split
+        self.reserved_profit_fraction, self.admin_fee = fee_split
         self.pool.set_fee_parameters(
-            self.lp_profit_fraction,
+            self.reserved_profit_fraction,
             self.admin_fee,
             sender=self.admin,
         )
         note(
-            "fee split lp_profit_fraction={:.2e} admin_fee={:.2e}".format(
-                self.lp_profit_fraction,
+            "fee split reserved_profit_fraction={:.2e} admin_fee={:.2e}".format(
+                self.reserved_profit_fraction,
                 self.admin_fee,
             )
         )

--- a/tests/unitary/pool/test_claim_admin_fees.py
+++ b/tests/unitary/pool/test_claim_admin_fees.py
@@ -56,6 +56,10 @@ def _trigger_one_delayed_rebalance(pool_instance):
     assert pool_instance.price_scale() != price_scale_before
 
 
+def _last_admin_fee_claim_timestamp(pool_instance):
+    return pool_instance.eval("self.last_admin_fee_claim_timestamp")
+
+
 def get_pool_state(pool_instance, print_state=False, print_normalized=True):
     xcp_profit = pool_instance.xcp_profit()
     virtual_price = pool_instance.virtual_price()
@@ -222,6 +226,67 @@ def test_claim_no_rebalancing(gm_pool, fee_receiver):
     assert value_received == pytest.approx(expected_admin_value, rel=1e-8)
     assert pool_instance.xcp_profit() == xcp_profit_pre_claim
     assert [pool_instance.admin_balances(i) for i in range(2)] == [0, 0]
+
+
+def test_empty_claim_does_not_update_timestamp_or_emit(gm_pool):
+    with boa.env.anchor():
+        pool_instance = gm_pool
+        gm_pool.add_liquidity_balanced(1_500_000 * 10**18)
+        boa.env.time_travel(seconds=UNIX_DAY)
+
+        assert [pool_instance.admin_balances(i) for i in range(2)] == [0, 0]
+        last_claim_time = _last_admin_fee_claim_timestamp(pool_instance)
+
+        pool_instance.get_logs()
+        pool_instance.internal._claim_admin_fees()
+        logs = pool_instance.get_logs()
+
+        assert _last_admin_fee_claim_timestamp(pool_instance) == last_claim_time
+        assert "ClaimAdminFee" not in [type(log).__name__ for log in logs]
+
+
+def test_empty_auto_claim_does_not_consume_interval(gm_pool):
+    with boa.env.anchor():
+        pool_instance = gm_pool
+        gm_pool.add_liquidity_balanced(1_500_000 * 10**18)
+        boa.env.time_travel(seconds=UNIX_DAY)
+
+        assert [pool_instance.admin_balances(i) for i in range(2)] == [0, 0]
+        last_claim_time = _last_admin_fee_claim_timestamp(pool_instance)
+
+        pool_instance.get_logs()
+        pool_instance.remove_liquidity_one_coin(pool_instance.balanceOf(boa.env.eoa) // 100, 0, 0)
+        logs = pool_instance.get_logs()
+
+        assert _last_admin_fee_claim_timestamp(pool_instance) == last_claim_time
+        assert "ClaimAdminFee" not in [type(log).__name__ for log in logs]
+
+
+def test_nonempty_auto_claim_transfers_cached_fees(gm_pool, fee_receiver):
+    with boa.env.anchor():
+        pool_instance = gm_pool
+        gm_pool.add_liquidity_balanced(1_500_000 * 10**18)
+        work_pool(pool_instance, N_TRADES, TRADE_SIZE, update_ema=False)
+        balance_pool(pool_instance)
+        boa.env.time_travel(seconds=UNIX_DAY)
+
+        expected_admin_amounts = [pool_instance.admin_balances(i) for i in range(2)]
+        assert sum(expected_admin_amounts) > 0
+        receiver_balances_init = [coin.balanceOf(fee_receiver) for coin in pool_instance.coins]
+
+        pool_instance.get_logs()
+        pool_instance.remove_liquidity_one_coin(pool_instance.balanceOf(boa.env.eoa) // 100, 0, 0)
+        logs = pool_instance.get_logs()
+
+        receiver_balances_post = [coin.balanceOf(fee_receiver) for coin in pool_instance.coins]
+        claim_logs = [log for log in logs if type(log).__name__ == "ClaimAdminFee"]
+
+        assert receiver_balances_post == [
+            receiver_balances_init[i] + expected_admin_amounts[i] for i in range(2)
+        ]
+        assert _last_admin_fee_claim_timestamp(pool_instance) == boa.env.evm.patch.timestamp
+        assert len(claim_logs) == 1
+        assert list(claim_logs[0].tokens) == expected_admin_amounts
 
 
 def test_n_claim_no_rebalancing(gm_pool, fee_receiver):

--- a/tests/unitary/pool/test_claim_admin_fees.py
+++ b/tests/unitary/pool/test_claim_admin_fees.py
@@ -1,6 +1,8 @@
 import boa
 import pytest
 
+from tests.utils.constants import FEE_PRECISION, UNIX_DAY
+
 # boa.env.evm.patch.code_size_limit = 56_000
 # TRADE_SIZE = 3 # times pool liq
 TRADE_SIZE = 1_000_000 * 10**18
@@ -29,6 +31,29 @@ def snapshot_balances(pool, actors):
         bals = [pool.coins[0].balanceOf(actor_addy), pool.coins[1].balanceOf(actor_addy)]
         balances[actor_addy] = bals
     return balances
+
+
+def _mint_balanced_liquidity(pool_instance, user, amount):
+    amounts = [amount, amount * 10**18 // pool_instance.price_scale()]
+    boa.deal(pool_instance.coins[0], user, amounts[0])
+    boa.deal(pool_instance.coins[1], user, amounts[1])
+    pool_instance.instance.add_liquidity(amounts, 0, sender=user)
+    return amounts
+
+
+def _set_price_oracle_target(pool_instance, ratio_num, ratio_den):
+    target_price = pool_instance.price_scale() * ratio_num // ratio_den
+    pool_instance.eval(f"self.last_prices = {target_price}")
+    pool_instance.eval(f"self.cached_price_oracle = {target_price}")
+    pool_instance.eval("self.last_timestamp = block.timestamp")
+
+
+def _trigger_one_delayed_rebalance(pool_instance):
+    _set_price_oracle_target(pool_instance, 102, 100)
+    boa.env.time_travel(seconds=7 * UNIX_DAY)
+    price_scale_before = pool_instance.price_scale()
+    pool_instance.exchange(0, pool_instance.balances(0) // 5, update_ema=False)
+    assert pool_instance.price_scale() != price_scale_before
 
 
 def get_pool_state(pool_instance, print_state=False, print_normalized=True):
@@ -482,6 +507,73 @@ def test_n_claim_lp_rebalancing(gm_pool, fee_receiver):
         assert [pool_instance.admin_balances(i) for i in range(2)] == [0, 0]
         assert 0 < rate_received_admin < 0.5
         assert 0.5 < rate_received_lp_user < 1
+
+
+def test_lp_earnings_after_delayed_rebalance_do_not_depend_on_admin_claim(gm_pool, factory_admin):
+    with boa.env.anchor():
+        boa.env.enable_fast_mode()
+        pool_instance = gm_pool
+        pool_instance.set_fee_parameters(
+            FEE_PRECISION // 2,
+            FEE_PRECISION // 2,
+            sender=factory_admin,
+        )
+
+        dead_lp_user = boa.env.generate_address()
+        tracked_lp_user = boa.env.generate_address()
+        for user in [dead_lp_user, tracked_lp_user]:
+            boa.env.set_balance(user, 10**20)
+            for coin in pool_instance.coins:
+                coin.approve(pool_instance, 2**256 - 1, sender=user)
+
+        _mint_balanced_liquidity(pool_instance, dead_lp_user, 1 * 10**18)
+
+        tracked_lp_value_init = sum(coin0_values(pool_instance, tracked_lp_user))
+        _mint_balanced_liquidity(pool_instance, tracked_lp_user, 1_000_000 * 10**18)
+
+        pool_value_with_lp = sum(coin0_values(pool_instance, pool_instance.address))
+        tracked_lp_share = (
+            pool_instance.balanceOf(tracked_lp_user) * 10**18 // pool_instance.totalSupply()
+        )
+        assert tracked_lp_share > 0
+
+        work_pool(pool_instance, N_TRADES, TRADE_SIZE, update_ema=False, xcp_growth=0.2)
+        balance_pool(pool_instance, update_ema=False)
+
+        pool_value_after_work = sum(coin0_values(pool_instance, pool_instance.address))
+        gross_profit = pool_value_after_work - pool_value_with_lp
+        assert gross_profit > 0
+        assert sum(pool_instance.admin_balances(i) for i in range(2)) > 0
+
+        def run_branch(claim_admin):
+            with boa.env.anchor():
+                if claim_admin:
+                    pool_instance.internal._claim_admin_fees()
+
+                _trigger_one_delayed_rebalance(pool_instance)
+                pool_instance.instance.remove_liquidity(
+                    pool_instance.balanceOf(tracked_lp_user),
+                    [0, 0],
+                    sender=tracked_lp_user,
+                )
+                tracked_lp_value_post = sum(coin0_values(pool_instance, tracked_lp_user))
+                return tracked_lp_value_post - tracked_lp_value_init
+
+        lp_earnings_without_claim = run_branch(False)
+        lp_earnings_with_claim = run_branch(True)
+
+        expected_lp_reserve = (
+            gross_profit
+            * (FEE_PRECISION // 2)
+            * (FEE_PRECISION - FEE_PRECISION // 2)
+            // FEE_PRECISION
+            // FEE_PRECISION
+            * tracked_lp_share
+            // 10**18
+        )
+
+        assert lp_earnings_with_claim == pytest.approx(lp_earnings_without_claim, rel=1e-8)
+        assert lp_earnings_without_claim >= expected_lp_reserve * 98 // 100
 
 
 def test_lp_deposit_fee_balanced(gm_pool, fee_receiver):

--- a/tests/unitary/pool/test_claim_admin_fees.py
+++ b/tests/unitary/pool/test_claim_admin_fees.py
@@ -174,8 +174,6 @@ def test_claim_no_rebalancing(gm_pool, fee_receiver):
 
     pool_values_post = coin0_values(pool_instance, pool_instance.address)
     xcp_profit_pre_claim = pool_instance.xcp_profit()
-    xcp_profit_a_pre_claim = pool_instance.xcp_profit_a()
-    admin_claimed_profit_pre = pool_instance.admin_claimed_profit()
 
     pool_values_change = [pool_values_post[i] - pool_values_init[i] for i in [0, 1]]
     pool_value_surplus = sum(pool_values_change)
@@ -183,30 +181,22 @@ def test_claim_no_rebalancing(gm_pool, fee_receiver):
     # pool value must increase (we washtraded fees)
     assert pool_value_surplus > 0
 
-    estimated_profit_admin_lp = pool_value_surplus // 2  # half to rebalance, half to admin-lp
-    estimated_profit_admin = estimated_profit_admin_lp * pool_instance.admin_fee() // 10**10
-
     # admin has 0 balance before claiming
     receiver_values_init = coin0_values(pool_instance, fee_receiver)
     assert sum(receiver_values_init) == 0
+    expected_admin_value = (
+        pool_instance.admin_balances(0)
+        + pool_instance.admin_balances(1) * pool_instance.price_scale() // 10**18
+    )
 
     # claim admin fees
     pool_instance.internal._claim_admin_fees()
     receiver_values_post = coin0_values(pool_instance, fee_receiver)
-    expected_fees = (
-        (xcp_profit_pre_claim - xcp_profit_a_pre_claim)
-        * pool_instance.lp_profit_fraction()
-        * pool_instance.admin_fee()
-        // 10**10
-        // 10**10
-    )
 
     value_received = sum(receiver_values_post) - sum(receiver_values_init)
-    # approx because add_liq doesn't earn for xcp_profit
-    assert value_received == pytest.approx(estimated_profit_admin, rel=1e-8)
+    assert value_received == pytest.approx(expected_admin_value, rel=1e-8)
     assert pool_instance.xcp_profit() == xcp_profit_pre_claim
-    assert pool_instance.xcp_profit_a() == xcp_profit_pre_claim
-    assert pool_instance.admin_claimed_profit() == admin_claimed_profit_pre + expected_fees
+    assert [pool_instance.admin_balances(i) for i in range(2)] == [0, 0]
 
 
 def test_n_claim_no_rebalancing(gm_pool, fee_receiver):
@@ -222,57 +212,32 @@ def test_n_claim_no_rebalancing(gm_pool, fee_receiver):
     assert pool_instance.coins[0].balanceOf(fee_receiver) == 0
     assert pool_instance.coins[1].balanceOf(fee_receiver) == 0
 
-    expected_admin_claimed_profit = 0
-
     for _ in range(N_REP):
         boa.env.time_travel(seconds=86_400)  # so that we can claim repeatedly
 
         pool_values_init = coin0_values(pool_instance, pool_instance.address)
-        P_init = pool_instance.xcp_profit()
-        P_a_init = pool_instance.xcp_profit_a()
 
         work_pool(pool_instance, N_TRADES, TRADE_SIZE, update_ema=False)
         balance_pool(pool_instance)
 
         pool_values_post = coin0_values(pool_instance, pool_instance.address)
         P_post = pool_instance.xcp_profit()
-        VP_post = pool_instance.virtual_price()
-        # fees_admin_lp = int(np.sqrt(P_post * 1e18) - np.sqrt(P_init * 1e18))
-        fees_admin_lp = (P_post - P_init) // 2
-        fees_admin = fees_admin_lp * pool_instance.admin_fee() // 10**10
-        estimated_profit_admin_vp_rated = fees_admin * sum(pool_values_post) // VP_post
-        estimated_profit_admin_absolute = (
-            (sum(pool_values_post) - sum(pool_values_init))
-            * pool_instance.admin_fee()
-            // 10**10
-            // 2
-        )
-        # vp-defined rate and absolute values must match
-        assert estimated_profit_admin_vp_rated == pytest.approx(
-            estimated_profit_admin_absolute, rel=1e-2
-        )
-        estimated_profit_admin = estimated_profit_admin_absolute
         pool_value_surplus = sum(pool_values_post) - sum(pool_values_init)
         assert pool_value_surplus > 0
 
         receiver_values_init = coin0_values(pool_instance, fee_receiver)
+        expected_admin_value = (
+            pool_instance.admin_balances(0)
+            + pool_instance.admin_balances(1) * pool_instance.price_scale() // 10**18
+        )
         pool_instance.internal._claim_admin_fees()
         receiver_values_post = coin0_values(pool_instance, fee_receiver)
-        expected_fees = (
-            (P_post - P_a_init)
-            * pool_instance.lp_profit_fraction()
-            * pool_instance.admin_fee()
-            // 10**10
-            // 10**10
-        )
-        expected_admin_claimed_profit += expected_fees
 
         value_received = sum(receiver_values_post) - sum(receiver_values_init)
 
-        assert value_received == pytest.approx(estimated_profit_admin, rel=1e-2)
+        assert value_received == pytest.approx(expected_admin_value, rel=1e-8)
         assert pool_instance.xcp_profit() == P_post
-        assert pool_instance.xcp_profit_a() == P_post
-        assert pool_instance.admin_claimed_profit() == expected_admin_claimed_profit
+        assert [pool_instance.admin_balances(i) for i in range(2)] == [0, 0]
 
 
 def test_n_claim_lp_no_rebalancing(gm_pool, fee_receiver):
@@ -352,6 +317,10 @@ def test_n_claim_lp_no_rebalancing(gm_pool, fee_receiver):
         assert pool_value_surplus > 0
 
         receiver_value_init = sum(coin0_values(pool_instance, fee_receiver))
+        expected_admin_value = (
+            pool_instance.admin_balances(0)
+            + pool_instance.admin_balances(1) * pool_instance.price_scale() // 10**18
+        )
         pool_instance.internal._claim_admin_fees()
         receiver_value_post = sum(coin0_values(pool_instance, fee_receiver))
         value_received_admin = receiver_value_post - receiver_value_init
@@ -369,11 +338,8 @@ def test_n_claim_lp_no_rebalancing(gm_pool, fee_receiver):
         # print(f"rate_received_lp_rate_adjusted: {value_received_lp_user / (pool_value_surplus * lp_user_balance_rate)}")
         # print(f"virtual_price: {pool_instance.virtual_price()/1e18}")
 
-        # admin always gets quarter of profits
-        expected_value_received_admin = (
-            pool_value_surplus * pool_instance.admin_fee() // 10**10 // 2
-        )
-        assert value_received_admin == pytest.approx(expected_value_received_admin, rel=0.01)
+        assert value_received_admin == pytest.approx(expected_admin_value, rel=1e-8)
+        assert [pool_instance.admin_balances(i) for i in range(2)] == [0, 0]
 
         profit_after_admin = pool_value_surplus - value_received_admin
         # LPs get rest of profits that are unburned by rebalance
@@ -486,6 +452,10 @@ def test_n_claim_lp_rebalancing(gm_pool, fee_receiver):
         # assert pool_value_surplus > 0
 
         receiver_value_init = sum(coin0_values(pool_instance, fee_receiver))
+        expected_admin_value = (
+            pool_instance.admin_balances(0)
+            + pool_instance.admin_balances(1) * pool_instance.price_scale() // 10**18
+        )
         pool_instance.internal._claim_admin_fees()
         get_pool_state(pool_instance, print_state=True)
 
@@ -508,9 +478,9 @@ def test_n_claim_lp_rebalancing(gm_pool, fee_receiver):
         print(f"rate_received_lp_rate_adjusted: {rate_received_lp_user}")
         print(f"virtual_price: {pool_instance.virtual_price()/1e18}")
 
-        # admin should get at least 0.25 of profits (if no rebalances happened), and up to 0.5 (if all rebalance reserve is used)
-        assert 0.25 < rate_received_admin < 0.5
-        # LPs get half the profits (if all rebalance reserve is used), and more if rebalance reserve is not used
+        assert value_received_admin == pytest.approx(expected_admin_value, rel=1e-8)
+        assert [pool_instance.admin_balances(i) for i in range(2)] == [0, 0]
+        assert 0 < rate_received_admin < 0.5
         assert 0.5 < rate_received_lp_user < 1
 
 

--- a/tests/unitary/pool/test_claim_admin_fees_grid.py
+++ b/tests/unitary/pool/test_claim_admin_fees_grid.py
@@ -41,20 +41,20 @@ def work_pool(pool_instance, n_swaps, trade_size):
         pool_instance.exchange(1, int(amount_out), update_ema=False)
 
 
-# This is the first claim-fee test that exercises non-default lp_profit_fraction.
+# This is the first claim-fee test that exercises non-default reserved_profit_fraction.
 @pytest.mark.parametrize(
-    "lp_profit_fraction", [FEE_PRECISION // 10, FEE_PRECISION // 2, 9 * FEE_PRECISION // 10]
+    "reserved_profit_fraction", [FEE_PRECISION // 10, FEE_PRECISION // 2, 9 * FEE_PRECISION // 10]
 )
 @pytest.mark.parametrize(
     "admin_fee", [FEE_PRECISION // 10, FEE_PRECISION // 2, 9 * FEE_PRECISION // 10]
 )
 def test_claim_admin_fees_grid_no_rebalancing(
-    pool, factory_admin, fee_receiver, lp_profit_fraction, admin_fee
+    pool, factory_admin, fee_receiver, reserved_profit_fraction, admin_fee
 ):
     with boa.env.anchor():
         boa.env.enable_fast_mode()
         pool_instance = GodModePool(pool)
-        pool_instance.set_fee_parameters(lp_profit_fraction, admin_fee, sender=factory_admin)
+        pool_instance.set_fee_parameters(reserved_profit_fraction, admin_fee, sender=factory_admin)
         pool_instance.add_liquidity_balanced(INITIAL_LIQ)
 
         work_pool(pool_instance, N_TRADES, TRADE_SIZE)

--- a/tests/unitary/pool/test_claim_admin_fees_grid.py
+++ b/tests/unitary/pool/test_claim_admin_fees_grid.py
@@ -61,24 +61,15 @@ def test_claim_admin_fees_grid_no_rebalancing(
         balance_pool(pool_instance)
 
         xcp_profit_pre = pool_instance.xcp_profit()
-        xcp_profit_a_pre = pool_instance.xcp_profit_a()
-        admin_claimed_profit_pre = pool_instance.admin_claimed_profit()
         virtual_price_pre = pool_instance.virtual_price()
         D_pre = pool_instance.D()
-        balances_pre = pool_instance.balances()
         receiver_balances_pre = [
             pool_instance.coins[0].balanceOf(fee_receiver),
             pool_instance.coins[1].balanceOf(fee_receiver),
         ]
         receiver_value_pre = sum(coin0_values(pool_instance, fee_receiver))
 
-        accrued = xcp_profit_pre - xcp_profit_a_pre
-        expected_fees = accrued * lp_profit_fraction * admin_fee // FEE_PRECISION // FEE_PRECISION
-        expected_vp_post = virtual_price_pre - expected_fees
-        expected_D_post = D_pre - D_pre * expected_fees // virtual_price_pre
-        expected_admin_amounts = [
-            balances_pre[i] * expected_fees // virtual_price_pre for i in range(2)
-        ]
+        expected_admin_amounts = [pool_instance.admin_balances(i) for i in range(2)]
 
         pool_instance.internal._claim_admin_fees()
 
@@ -91,11 +82,10 @@ def test_claim_admin_fees_grid_no_rebalancing(
         ]
         assert actual_admin_amounts == expected_admin_amounts
 
-        assert pool_instance.virtual_price() == expected_vp_post
+        assert pool_instance.virtual_price() == virtual_price_pre
         assert pool_instance.xcp_profit() == xcp_profit_pre
-        assert pool_instance.xcp_profit_a() == xcp_profit_pre
-        assert pool_instance.admin_claimed_profit() == admin_claimed_profit_pre + expected_fees
-        assert pool_instance.D() == expected_D_post
+        assert pool_instance.D() == D_pre
+        assert [pool_instance.admin_balances(i) for i in range(2)] == [0, 0]
 
         receiver_value_post = sum(coin0_values(pool_instance, fee_receiver))
         expected_claim_value = sum(

--- a/tests/unitary/pool/test_donation.py
+++ b/tests/unitary/pool/test_donation.py
@@ -15,6 +15,14 @@ def test_cant_donate_on_empty_pool(gm_pool):
     assert gm_pool.totalSupply() == 0
 
 
+def test_empty_pool_donation_quote_is_zero(gm_pool, views_contract):
+    amounts = [10**18, 2 * 10**18]
+
+    assert gm_pool.D() == 0
+    assert views_contract.calc_token_amount(amounts, True, gm_pool.address, True) == 0
+    assert views_contract.calc_token_amount(amounts, True, gm_pool.address, False) > 0
+
+
 @fixture()
 def gm_pool_with_liquidity(gm_pool):
     gm_pool.add_liquidity_balanced(1_000 * 10**18)

--- a/tests/unitary/pool/test_donation.py
+++ b/tests/unitary/pool/test_donation.py
@@ -383,7 +383,7 @@ def test_remove_after_rebalancing(gm_pool):
     # donation_shares_pre = gm_pool.donation_shares()
     attacker_add_liquidity_amount_coin0 = 500_000 * 10**18
     # pool is imbalanced, and we add proportionally disbalanced liquidity
-    pool_balances = [gm_pool.coins[i].balanceOf(gm_pool) for i in range(N_COINS)]
+    pool_balances = [gm_pool.balances(i) for i in range(N_COINS)]
     fraction = (
         attacker_add_liquidity_amount_coin0 / pool_balances[0]
     )  # rate of coin0 to pool balance

--- a/tests/unitary/pool/test_rebalance_compounding.py
+++ b/tests/unitary/pool/test_rebalance_compounding.py
@@ -1,7 +1,7 @@
 import boa
 import pytest
 
-from tests.utils.constants import MAX_FEE, PRECISION, UNIX_DAY, VENOM_FLAG
+from tests.utils.constants import FEE_PRECISION, MAX_FEE, PRECISION, UNIX_DAY, VENOM_FLAG
 from tests.utils.god_mode import GodModePool
 
 POLICY_TARGET_NUM = 102
@@ -170,24 +170,39 @@ def _run_rebalance_probe(pool_instance):
 
 
 def _inject_threshold_probe(pool_instance):
-    pool_instance.inject_function(
-        """
+    try:
+        pool_instance.inject_function(
+            """
 @external
 @view
-def threshold_probe() -> uint256:
-    threshold_base: uint256 = (
-        10**18
-        + (max(self.xcp_profit, 10**18) - 10**18) * self.lp_profit_fraction // 10**10
-    )
-    threshold_vp: uint256 = threshold_base
-    if threshold_base > 10**18:
-        threshold_vp = unsafe_sub(
-            threshold_base,
-            min(self.admin_claimed_profit, unsafe_sub(threshold_base, 10**18)),
+def net_lp_reserve_fraction_probe() -> uint256:
+    reserved_fraction: uint256 = self.reserved_profit_fraction
+    admin_fee: uint256 = self.admin_fee
+    denominator: uint256 = 10**10 * 10**10 - reserved_fraction * admin_fee
+
+    net_lp_reserve_fraction: uint256 = 10**10
+    if denominator > 0:
+        net_lp_reserve_fraction = (
+            reserved_fraction * (10**10 - admin_fee) * 10**10 // denominator
         )
-    return threshold_vp
+    return net_lp_reserve_fraction
+
 """
-    )
+        )
+    except ValueError as e:
+        if "already injected" not in str(e):
+            raise
+
+
+def _net_lp_reserve_fraction(reserved_fraction, admin_fee):
+    denominator = FEE_PRECISION * FEE_PRECISION - reserved_fraction * admin_fee
+    if denominator == 0:
+        return FEE_PRECISION
+    return reserved_fraction * (FEE_PRECISION - admin_fee) * FEE_PRECISION // denominator
+
+
+def _threshold(xcp_profit, reserve_fraction):
+    return PRECISION + (max(xcp_profit, PRECISION) - PRECISION) * reserve_fraction // FEE_PRECISION
 
 
 def test_synthetic_vp_xcp_state_is_coherent(pool, factory_admin):
@@ -299,19 +314,77 @@ def test_price_scale_rebalances_only_on_first_touch_in_block(pool, factory_admin
         assert donation_shares_after_next_block < donation_shares_after_same_block
 
 
-def test_admin_claimed_profit_offsets_threshold_vp_with_floor(pool):
-    pytest.skip("admin_claimed_profit was removed in token-denominated admin fee accounting")
+@pytest.mark.parametrize(
+    "reserved_profit_fraction,admin_fee,expected_fraction",
+    [
+        (FEE_PRECISION // 2, FEE_PRECISION // 2, FEE_PRECISION // 3),
+        (FEE_PRECISION // 2, 0, FEE_PRECISION // 2),
+        (0, FEE_PRECISION // 2, 0),
+        (FEE_PRECISION, FEE_PRECISION // 2, FEE_PRECISION),
+        (FEE_PRECISION, FEE_PRECISION, FEE_PRECISION),
+    ],
+)
+def test_net_lp_reserve_fraction_probe(
+    pool, factory_admin, reserved_profit_fraction, admin_fee, expected_fraction
+):
+    with boa.env.anchor():
+        pool_instance = GodModePool(pool)
+        pool_instance.set_fee_parameters(
+            reserved_profit_fraction,
+            admin_fee,
+            sender=factory_admin,
+        )
+        _inject_threshold_probe(pool_instance)
+
+        assert pool_instance.instance.inject.net_lp_reserve_fraction_probe() == expected_fraction
+
+
+def test_net_admin_threshold_floor(pool, factory_admin):
     with boa.env.anchor():
         pool_instance = GodModePool(pool)
         pool_instance.add_liquidity_balanced(INITIAL_LIQ)
+        pool_instance.set_fee_parameters(
+            FEE_PRECISION // 2, FEE_PRECISION // 2, sender=factory_admin
+        )
         _inject_threshold_probe(pool_instance)
 
-        pool_instance.eval("self.xcp_profit = 3 * 10**18")
-        pool_instance.eval("self.admin_claimed_profit = 0")
-        assert pool_instance.instance.inject.threshold_probe() == 2 * PRECISION
+        pool_instance.eval("self.xcp_profit = 10**18 - 1")
+        net_lp_reserve_fraction = _net_lp_reserve_fraction(
+            pool_instance.reserved_profit_fraction(),
+            pool_instance.admin_fee(),
+        )
+        assert _threshold(pool_instance.xcp_profit(), net_lp_reserve_fraction) == PRECISION
 
-        pool_instance.eval("self.admin_claimed_profit = 3 * 10**17")
-        assert pool_instance.instance.inject.threshold_probe() == 17 * PRECISION // 10
 
-        pool_instance.eval("self.admin_claimed_profit = 5 * 10**18")
-        assert pool_instance.instance.inject.threshold_probe() == PRECISION
+def test_adjusted_threshold_allows_rebalance_when_raw_threshold_blocks(pool, factory_admin):
+    with boa.env.anchor():
+        boa.env.enable_fast_mode()
+        pool_instance = GodModePool(pool)
+        _deploy_two_percent_policy(pool, factory_admin)
+        pool_instance.add_liquidity_balanced(INITIAL_LIQ)
+        _set_probe_rebalancing_params(pool_instance, factory_admin)
+        _set_synthetic_high_state(pool_instance)
+
+        net_lp_reserve_fraction = _net_lp_reserve_fraction(
+            pool_instance.reserved_profit_fraction(),
+            pool_instance.admin_fee(),
+        )
+        adjusted_threshold = _threshold(pool_instance.xcp_profit(), net_lp_reserve_fraction)
+        raw_threshold = _threshold(
+            pool_instance.xcp_profit(),
+            pool_instance.reserved_profit_fraction(),
+        )
+        boosted_vp = pool_instance.virtual_price_boosted()
+
+        assert adjusted_threshold < boosted_vp
+        assert boosted_vp <= raw_threshold
+
+        boa.env.time_travel(seconds=7 * UNIX_DAY)
+        price_scale_before = pool_instance.price_scale()
+        pool_instance.exchange(
+            0,
+            pool_instance.balances(0) * REBALANCE_RATIO_NUM // REBALANCE_RATIO_DEN,
+            update_ema=False,
+        )
+
+        assert pool_instance.price_scale() != price_scale_before

--- a/tests/unitary/pool/test_rebalance_compounding.py
+++ b/tests/unitary/pool/test_rebalance_compounding.py
@@ -1,4 +1,5 @@
 import boa
+import pytest
 
 from tests.utils.constants import MAX_FEE, PRECISION, UNIX_DAY, VENOM_FLAG
 from tests.utils.god_mode import GodModePool
@@ -107,7 +108,7 @@ def _snapshot(pool_instance):
     return {
         "virtual_price": pool_instance.virtual_price(),
         "xcp_profit": pool_instance.xcp_profit(),
-        "admin_claimed_profit": pool_instance.admin_claimed_profit(),
+        "admin_balances": [pool_instance.admin_balances(i) for i in range(2)],
         "get_virtual_price": pool_instance.get_virtual_price(),
         "price_scale": pool_instance.price_scale(),
         "price_oracle": pool_instance.price_oracle(),
@@ -299,6 +300,7 @@ def test_price_scale_rebalances_only_on_first_touch_in_block(pool, factory_admin
 
 
 def test_admin_claimed_profit_offsets_threshold_vp_with_floor(pool):
+    pytest.skip("admin_claimed_profit was removed in token-denominated admin fee accounting")
     with boa.env.anchor():
         pool_instance = GodModePool(pool)
         pool_instance.add_liquidity_balanced(INITIAL_LIQ)

--- a/tests/unitary/twocrypto/test_add_liquidity.py
+++ b/tests/unitary/twocrypto/test_add_liquidity.py
@@ -67,7 +67,7 @@ def test_add_liquidity_existing_pool(pool, user_account, bob):
     assert pool.totalSupply() == initial_lp_total_supply + minted_lp
 
     for i in range(N_COINS):
-        assert pool.balances(i) == initial_balances[i] + add_amounts[i]
+        assert pool.balances(i) + pool.admin_balances(i) == initial_balances[i] + add_amounts[i]
 
     assert pool.D() > initial_D
 
@@ -112,16 +112,18 @@ def test_add_liquidity_fee_and_donation_protection(pool, user_account, bob, char
     # 0. seed pool
     initial_amounts = gm_pool.compute_balanced_amounts(INITIAL_LIQUIDITY)
     gm_pool.add_liquidity(initial_amounts)
+    gm_pool.donate_balanced(INITIAL_LIQUIDITY // 20)
 
-    # 1. user_account adds initial liquidity.
-    gm_pool.premint_amounts(initial_amounts, to=user_account)
-    pool.add_liquidity(initial_amounts, 0, sender=user_account)
+    # 1. user_account adds liquidity and extends donation protection.
+    user_adds_amounts = gm_pool.compute_balanced_amounts(INITIAL_LIQUIDITY // 2)
+    gm_pool.premint_amounts(user_adds_amounts, to=user_account)
+    pool.add_liquidity(user_adds_amounts, 0, sender=user_account)
     event1 = pool.get_logs()[-1]
     minted_lp1 = pool.balanceOf(user_account)
     fee_rate1 = event1.fee / (minted_lp1 + event1.fee)
 
     # 2. bob adds liquidity right after. This should incur a penalty.
-    bob_adds_amounts = gm_pool.compute_balanced_amounts(INITIAL_LIQUIDITY // 10)
+    bob_adds_amounts = gm_pool.compute_balanced_amounts(INITIAL_LIQUIDITY // 2)
     gm_pool.premint_amounts(bob_adds_amounts, to=bob)
     pool.add_liquidity(bob_adds_amounts, 0, sender=bob)
     event2 = pool.get_logs()[-1]
@@ -135,7 +137,7 @@ def test_add_liquidity_fee_and_donation_protection(pool, user_account, bob, char
     boa.env.time_travel(seconds=protection_period // 2)
 
     # 4. charlie adds liquidity. The fee should be lower than bob's.
-    charlie_adds_amounts = gm_pool.compute_balanced_amounts(INITIAL_LIQUIDITY // 10)
+    charlie_adds_amounts = gm_pool.compute_balanced_amounts(INITIAL_LIQUIDITY // 2)
     gm_pool.premint_amounts(charlie_adds_amounts, to=charlie)
     pool.add_liquidity(charlie_adds_amounts, 0, sender=charlie)
     event3 = pool.get_logs()[-1]
@@ -148,7 +150,7 @@ def test_add_liquidity_fee_and_donation_protection(pool, user_account, bob, char
     boa.env.time_travel(seconds=protection_period + 1)
 
     # 6. bob adds liquidity again. Fee should be back to base level.
-    bob_adds_again_amounts = gm_pool.compute_balanced_amounts(INITIAL_LIQUIDITY // 10)
+    bob_adds_again_amounts = gm_pool.compute_balanced_amounts(INITIAL_LIQUIDITY // 2)
     gm_pool.premint_amounts(bob_adds_again_amounts, to=bob)
     bob_initial_lp = pool.balanceOf(bob)
     pool.add_liquidity(bob_adds_again_amounts, 0, sender=bob)

--- a/tests/unitary/twocrypto/test_bootstrap_initialize.py
+++ b/tests/unitary/twocrypto/test_bootstrap_initialize.py
@@ -97,7 +97,7 @@ def test_deployer_can_initialize_and_seed_allowlist_with_policy(
     assert logs[-1].allowed is True
 
     assert pool.admin_fee() == 123
-    assert pool.lp_profit_fraction() == FEE_PRECISION // 4
+    assert pool.reserved_profit_fraction() == FEE_PRECISION // 4
     assert pool.POLICY() == policy.address
     assert policy.get_price_scale() == 0
 
@@ -188,7 +188,7 @@ def test_admin_can_initialize_and_leave_whitelist_disabled(
     assert logs[-1].allowed is False
 
     assert pool.admin_fee() == 321
-    assert pool.lp_profit_fraction() == FEE_PRECISION // 3
+    assert pool.reserved_profit_fraction() == FEE_PRECISION // 3
     assert pool.POLICY() == ZERO_ADDRESS
 
     minted = _premint_and_add(pool, coins, bob)

--- a/tests/unitary/twocrypto/test_policy_parity.py
+++ b/tests/unitary/twocrypto/test_policy_parity.py
@@ -20,8 +20,7 @@ def _state_snapshot(pool):
         "last_prices": pool.last_prices(),
         "virtual_price": pool.virtual_price(),
         "xcp_profit": pool.xcp_profit(),
-        "xcp_profit_a": pool.xcp_profit_a(),
-        "admin_claimed_profit": pool.admin_claimed_profit(),
+        "admin_balances": [pool.admin_balances(i) for i in range(2)],
     }
 
 

--- a/tests/unitary/twocrypto/test_remove_liquidity.py
+++ b/tests/unitary/twocrypto/test_remove_liquidity.py
@@ -1,7 +1,7 @@
 import boa
 import pytest
 
-from tests.utils.constants import N_COINS, VENOM_FLAG
+from tests.utils.constants import N_COINS, POLICY_DEPLOYER, VENOM_FLAG
 from tests.utils.god_mode import GodModePool
 import numpy as np
 
@@ -209,6 +209,39 @@ def test_remove_liquidity_ignores_reverting_policy_update(pool, coins, factory_a
             coins[i].balanceOf(user_account)
             == initial_user_coin_balances[i] + expected_withdraw_amounts[i]
         )
+
+
+def test_zero_balanced_remove_liquidity_skips_policy_update(pool, factory_admin):
+    with boa.env.anchor():
+        gm_pool = GodModePool(pool)
+        gm_pool.add_liquidity_balanced(amount=INITIAL_LIQUIDITY_COIN0)
+
+        policy = POLICY_DEPLOYER.deploy(pool.address)
+        pool.set_policy_contract(policy, sender=factory_admin)
+        last_ts = policy.last_pool_state().ts
+        assert last_ts > 0
+
+        boa.env.time_travel(seconds=1)
+        assert pool.remove_liquidity(0, [0] * N_COINS) == [0] * N_COINS
+
+        assert policy.last_pool_state().ts == last_ts
+
+
+def test_nonzero_balanced_remove_liquidity_updates_policy(pool, factory_admin):
+    with boa.env.anchor():
+        gm_pool = GodModePool(pool)
+        gm_pool.add_liquidity_balanced(amount=INITIAL_LIQUIDITY_COIN0)
+
+        policy = POLICY_DEPLOYER.deploy(pool.address)
+        pool.set_policy_contract(policy, sender=factory_admin)
+        last_ts = policy.last_pool_state().ts
+        assert last_ts > 0
+
+        boa.env.time_travel(seconds=1)
+        withdraw_amounts = pool.remove_liquidity(pool.balanceOf(boa.env.eoa) // 2, [0] * N_COINS)
+
+        assert withdraw_amounts[0] > 0 or withdraw_amounts[1] > 0
+        assert policy.last_pool_state().ts > last_ts
 
 
 def test_remove_liquidity_slippage(pool, coins, bob):

--- a/tests/unitary/twocrypto/test_set_donation_parameters.py
+++ b/tests/unitary/twocrypto/test_set_donation_parameters.py
@@ -42,7 +42,9 @@ def test_only_owner(pool):
         (0, 1, 1, 1, '"donation duration cannot be zero"'),
         (1, 0, 1, 1, '"donation protection period cannot be zero"'),
         (1, 1, 0, 1, '"donation protection threshold cannot be zero"'),
+        (1, 1, PRECISION + 1, 1, '"donation protection threshold above 1e18"'),
         (1, 1, 1, 0, '"donation shares max ratio cannot be zero"'),
+        (1, 1, 1, PRECISION + 1, '"donation shares max ratio above 1e18"'),
     ],
 )
 def test_invalid_params(pool, duration, period, threshold, max_shares_ratio, dev_reason):

--- a/tests/unitary/twocrypto/test_set_fee_parameters.py
+++ b/tests/unitary/twocrypto/test_set_fee_parameters.py
@@ -5,18 +5,18 @@ from tests.utils.constants import FEE_PRECISION
 
 
 @pytest.mark.parametrize("admin_fee", [int(i * 10**10 / 4) for i in range(5)])
-@pytest.mark.parametrize("lp_profit_fraction", [0, FEE_PRECISION // 2, FEE_PRECISION])
-def test_default_behavior(pool, factory_admin, admin_fee, lp_profit_fraction):
-    pool.set_fee_parameters(lp_profit_fraction, admin_fee, sender=factory_admin)
+@pytest.mark.parametrize("reserved_profit_fraction", [0, FEE_PRECISION // 2, FEE_PRECISION])
+def test_default_behavior(pool, factory_admin, admin_fee, reserved_profit_fraction):
+    pool.set_fee_parameters(reserved_profit_fraction, admin_fee, sender=factory_admin)
 
     logs = pool.get_logs()
     assert len(logs) == 1
     assert type(logs[0]).__name__ == "SetFeeParameters"
     assert logs[0].admin_fee == admin_fee
-    assert logs[0].lp_profit_fraction == lp_profit_fraction
+    assert logs[0].reserved_profit_fraction == reserved_profit_fraction
 
     assert pool.admin_fee() == admin_fee
-    assert pool.lp_profit_fraction() == lp_profit_fraction
+    assert pool.reserved_profit_fraction() == reserved_profit_fraction
 
 
 def test_only_owner(pool):
@@ -29,6 +29,6 @@ def test_admin_fee_greater_than_max(pool, factory_admin):
         pool.set_fee_parameters(0, 10**10 + 1, sender=factory_admin)
 
 
-def test_lp_profit_fraction_greater_than_precision(pool, factory_admin):
-    with boa.reverts(dev='"lp profit fraction above 1e10"'):
+def test_reserved_profit_fraction_greater_than_precision(pool, factory_admin):
+    with boa.reverts(dev='"reserved profit fraction above 1e10"'):
         pool.set_fee_parameters(FEE_PRECISION + 1, 0, sender=factory_admin)

--- a/tests/utils/god_mode.py
+++ b/tests/utils/god_mode.py
@@ -120,11 +120,13 @@ class GodModePool:
             "user_lp": self.instance.balanceOf(boa.env.eoa),
             "lp_supply": self.instance.totalSupply(),
             "user_coins": [self.coins[i].balanceOf(boa.env.eoa) for i in range(N_COINS)],
-            "pool_coins": [self.instance.balances(i) for i in range(N_COINS)],
+            "pool_coins": [self.coins[i].balanceOf(self.instance) for i in range(N_COINS)],
+            "pool_owned_coins": [self.instance.balances(i) for i in range(N_COINS)],
+            "admin_coins": [self.instance.admin_balances(i) for i in range(N_COINS)],
         }
-        assert snapshot["pool_coins"] == [
-            self.coins[i].balanceOf(self.instance) for i in range(N_COINS)
-        ], "pool coins balances are not consistent"
+        assert [
+            snapshot["pool_owned_coins"][i] + snapshot["admin_coins"][i] for i in range(N_COINS)
+        ] == snapshot["pool_coins"], "pool coins balances are not consistent"
         return snapshot
 
     def get_metrics_snapshot(self):
@@ -132,14 +134,14 @@ class GodModePool:
         return {
             "virtual_price": self.instance.virtual_price(),
             "xcp_profit": self.instance.xcp_profit(),
-            "xcp_profit_a": self.instance.xcp_profit_a(),
-            "admin_claimed_profit": self.instance.admin_claimed_profit(),
             "price_scale": self.instance.price_scale(),
             "price_oracle": self.instance.price_oracle(),
             "total_supply": self.instance.totalSupply(),
             "D": self.instance.D(),
             "coin0_balance": self.instance.balances(0),
             "coin1_balance": self.instance.balances(1),
+            "coin0_admin_balance": self.instance.admin_balances(0),
+            "coin1_admin_balance": self.instance.admin_balances(1),
         }
 
     def premint_amounts(self, amounts, to=god):


### PR DESCRIPTION
 ## Summary

  Refactor admin fees to be token-denominated.

  Admin fees are now booked immediately into `admin_balances` and excluded from AMM-owned `balances`, so they are permanently outside `virtual_price`, `xcp_profit`, `D`, and pool liquidity. Claiming fees only transfers cached
  token balances to the fee receiver and no longer mutates AMM accounting.

  This simplifies `tweak_price` reasoning by removing the old vp/xcp_profit-denominated admin-fee surface.

  ## Bytecode / Gas

  The refactor increases bytecode, so the pool now uses `# pragma optimize codesize`, relying on Vyper’s dense selector table optimization:
  https://github.com/vyperlang/vyper/pull/3496

  Local profiling shows about `-1 KB` runtime bytecode for a small mostly flat cost: `+139` gas on add/exchange/one-coin remove, and `+255` gas on balanced remove.
